### PR TITLE
Fixed the scripts path in example 5

### DIFF
--- a/examples/5_docker_turtlesim/README.md
+++ b/examples/5_docker_turtlesim/README.md
@@ -55,7 +55,7 @@ docker compose build --no-cache turtlesim
 The easiest way to launch turtlesim with proper X11 setup:
 
 ```bash
-./launch.sh
+./scrips/launch.sh
 ```
 
 This script automatically detects your OS and handles all platform-specific X11 configuration. It will:
@@ -69,17 +69,17 @@ If you prefer manual control or the automatic script doesn't work:
 
 **macOS:**
 ```bash
-./docker/scripts/launch_macos.sh
+./scripts/launch_macos.sh
 ```
 
 **Linux (or Windows WSL):**
 ```bash
-./docker/scripts/launch_linux.sh
+./scripts/launch_linux.sh
 ```
 
 **Windows:**
 ```bash
-./docker/scripts/launch_windows.sh
+./scripts/launch_windows.sh
 ```
 
 The container will automatically start both turtlesim and rosbridge websocket server. You should see:

--- a/examples/5_docker_turtlesim/scripts/launch.sh
+++ b/examples/5_docker_turtlesim/scripts/launch.sh
@@ -9,22 +9,22 @@ OS_TYPE=$(uname -s)
 case "$OS_TYPE" in
     Darwin*)
         echo "Detected macOS - launching with XQuartz support..."
-        ./docker/scripts/launch_macos.sh
+        ./scripts/launch_macos.sh
         ;;
     Linux*)
         echo "Detected Linux - launching with X11 support..."
-        ./docker/scripts/launch_linux.sh
+        ./scripts/launch_linux.sh
         ;;
     MINGW*|MSYS*|CYGWIN*)
         echo "Detected Windows - launching with X server support..."
-        ./docker/scripts/launch_windows.sh
+        ./scripts/launch_windows.sh
         ;;
     *)
         echo "Unsupported OS: $OS_TYPE"
         echo "   Please run the appropriate script manually:"
-        echo "   - macOS: ./docker/scripts/launch_macos.sh"
-        echo "   - Linux: ./docker/scripts/launch_linux.sh"
-        echo "   - Windows: ./docker/scripts/launch_windows.sh"
+        echo "   - macOS: ./scripts/launch_macos.sh"
+        echo "   - Linux: ./scripts/launch_linux.sh"
+        echo "   - Windows: ./scripts/launch_windows.sh"
         exit 1
         ;;
 esac


### PR DESCRIPTION
Fixed the setup scripts path from `./docker/scripts/launch_.sh` to `./scripts/launch_.sh` as the docker folder was removed. 
I have updated both the bash scripts and README. 

Fixes the merge: #186 
