### PR TITLE
fix: use consistent image path for compressed and raw images

### DIFF
--- a/utils/websocket_manager.py
+++ b/utils/websocket_manager.py
@@ -137,7 +137,7 @@ def parse_image(raw: Union[str, bytes] | None) -> dict | None:
 
 def _handle_compressed_image(data_b64: str, result: dict) -> dict | None:
     """Handle compressed image data (JPEG/PNG already encoded)."""
-    path = "./camera/received_image_compressed.jpeg"
+    path = "./camera/received_image.jpeg"
     image_bytes = base64.b64decode(data_b64)
 
     with open(path, "wb") as f:


### PR DESCRIPTION
Previously, compressed images were saved to `./camera/received_image_compressed.jpeg` while raw images were saved to `./camera/received_image.jpeg`. This caused the `analyze_previously_received_image` tool to fail when trying to analyze compressed images, as it only looks for `./camera/received_image.jpeg`.

This commit standardizes the path for both compressed and raw images to use `./camera/received_image.jpeg`, ensuring that the analysis tool can find images regardless of their original format.