### PR TITLE
Fix packaging configuration: add missing modules and correct entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 ]
 
 [project.scripts]
-ros-mcp = "ros_mcp.server:main"
+ros-mcp = "ros_mcp.main:main"
 
 [build-system]
 requires = ["setuptools>=68", "wheel"]
@@ -37,7 +37,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 include-package-data = true
-packages = ["ros_mcp", "ros_mcp.tools", "ros_mcp.utils", "config", "robot_specifications"]
+packages = ["ros_mcp", "ros_mcp.tools", "ros_mcp.utils", "ros_mcp.prompts", "ros_mcp.resources", "config", "robot_specifications"]
 
 [tool.setuptools.package-data]
 robot_specifications = ["*.yaml"]


### PR DESCRIPTION
## Problem
When running `uvx .` in the project root, the installation would fail with:
1. `ModuleNotFoundError: No module named 'ros_mcp.prompts'` 
2. `ModuleNotFoundError: No module named 'ros_mcp.server'`

Potentially this could be the reason why prompts and resources were not visible in Claude.

## Solution
This PR fixes the packaging configuration in `pyproject.toml`:

1. **Added missing packages**: Added `ros_mcp.prompts` and `ros_mcp.resources` to the `packages` list in `[tool.setuptools]`. These modules exist in the codebase but were not being included in the installed package.

2. **Fixed entry point**: Corrected the entry point from `ros_mcp.server:main` to `ros_mcp.main:main`. The `ros_mcp.server` module doesn't exist; the `main()` function is actually in `ros_mcp.main`.

## Testing
After these changes, `uvx .` now successfully builds and installs the package without import errors.

## Changes
- `pyproject.toml`: Added `ros_mcp.prompts` and `ros_mcp.resources` to packages list
- `pyproject.toml`: Fixed entry point from `ros_mcp.server:main` to `ros_mcp.main:main`