### PR TITLE
feat: add integration.py for parent server registration

### DIFF
--- a/ros_mcp/integration.py
+++ b/ros_mcp/integration.py
@@ -4,13 +4,15 @@ This module provides the register() function called by submodule_integration.py.
 It reads its own configuration from environment variables, keeping ROS-specific
 configuration encapsulated within this submodule.
 """
-import os
+
 import logging
+import os
 
 from fastmcp import FastMCP
-from ros_mcp.tools import register_all_tools
-from ros_mcp.resources import register_all_resources
+
 from ros_mcp.prompts import register_all_prompts
+from ros_mcp.resources import register_all_resources
+from ros_mcp.tools import register_all_tools
 from ros_mcp.utils.websocket import WebSocketManager
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
# Summary
- Add `ros_mcp/integration.py` module for parent server registration
- Enables submodule to own its own configuration (rosbridge IP/port)

## Changes
The new `integration.py` provides a `register(mcp)` function that:
- Reads `ROSBRIDGE_IP`, `ROSBRIDGE_PORT`, `ROS_DEFAULT_TIMEOUT` from environment variables
- Creates the `WebSocketManager` internally
- Registers all tools, resources, and prompts with the provided FastMCP instance

This allows parent servers (like robotmcp_server) to be completely submodule-agnostic - they just call `register(mcp)` without needing to know about rosbridge configuration.

# Ready for Review