### PR TITLE
feat: add E2E tests with ROS 1/ROS 2 Docker support

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,115 @@
+name: E2E Tests
+
+on:
+  pull_request:
+  push:
+    branches: [develop, main]
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install -e ".[dev]"
+
+      - name: Run unit tests
+        run: |
+          pytest tests/utils tests/tools -v --tb=short
+
+      - name: Run unit tests with coverage
+        run: |
+          pytest tests/utils tests/tools --cov=ros_mcp --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+        continue-on-error: true
+
+  e2e-tests:
+    name: E2E Tests with ROS 2 Turtlesim
+    runs-on: ubuntu-latest
+    needs: unit-tests  # Run after unit tests pass
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install -e ".[dev]"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ROS 2 turtlesim container
+        run: |
+          docker-compose -f tests/e2e/docker-compose.e2e.yml build
+
+      - name: Start ROS 2 turtlesim container
+        run: |
+          docker-compose -f tests/e2e/docker-compose.e2e.yml up -d
+
+      - name: Wait for rosbridge to be ready
+        run: |
+          echo "Waiting for rosbridge to be ready..."
+          for i in {1..60}; do
+            if nc -z localhost 9090 2>/dev/null; then
+              echo "rosbridge is ready after $i seconds"
+              # Extra wait for ROS to fully initialize
+              sleep 10
+              break
+            fi
+            echo "Waiting... ($i/60)"
+            sleep 1
+          done
+          # Final check
+          nc -z localhost 9090 || (echo "rosbridge not ready" && exit 1)
+
+      - name: Show container logs (pre-test)
+        run: |
+          docker-compose -f tests/e2e/docker-compose.e2e.yml logs --tail=50
+
+      - name: Run E2E tests
+        run: |
+          pytest tests/e2e/ -v --timeout=120 -m e2e
+
+      - name: Show container logs (post-test)
+        if: always()
+        run: |
+          docker-compose -f tests/e2e/docker-compose.e2e.yml logs --tail=100
+
+      - name: Stop containers
+        if: always()
+        run: |
+          docker-compose -f tests/e2e/docker-compose.e2e.yml down
+
+  all-tests:
+    name: All Tests Summary
+    runs-on: ubuntu-latest
+    needs: [unit-tests, e2e-tests]
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.unit-tests.result }}" == "failure" ] || \
+             [ "${{ needs.e2e-tests.result }}" == "failure" ]; then
+            echo "Tests failed"
+            exit 1
+          fi
+          echo "All tests passed!"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,76 @@
 # Testing Guide for ROS MCP Server
 
-This guide explains how to test the ROS MCP Server using prompts and resources.
+This guide explains how to test the ROS MCP Server using prompts, resources, and automated tests.
+
+## Running E2E Tests
+
+E2E tests require a ROS environment with turtlesim running in Docker. The test suite supports both ROS 1 (Noetic) and ROS 2 (Humble).
+
+### Prerequisites
+
+- Docker and Docker Compose installed
+- pytest (`pip install pytest pytest-timeout pytest-asyncio`)
+
+### ROS 2 E2E Tests (Default)
+
+```bash
+# Start the ROS 2 environment
+docker compose -f tests/e2e/docker-compose.e2e.yml up -d
+
+# Wait for rosbridge to be ready (typically 10-30 seconds)
+sleep 30
+
+# Run E2E tests (default is ROS 2)
+pytest tests/e2e/ -v -m e2e
+
+# Run specific E2E test category
+pytest tests/e2e/test_e2e_topics.py -v -m e2e
+
+# Stop the Docker environment
+docker compose -f tests/e2e/docker-compose.e2e.yml down
+```
+
+### ROS 1 E2E Tests
+
+```bash
+# Start the ROS 1 environment (uses port 9091)
+docker compose -f tests/e2e/docker-compose.ros1.yml up -d
+
+# Wait for rosbridge to be ready
+sleep 30
+
+# Run E2E tests with ROS 1
+pytest tests/e2e/ -v -m e2e --ros-version=1
+
+# Run only tests compatible with ROS 1 (excludes ros2-only tests)
+pytest tests/e2e/ -v -m "e2e and not ros2" --ros-version=1
+
+# Stop the Docker environment
+docker compose -f tests/e2e/docker-compose.ros1.yml down
+```
+
+### E2E Test Files
+
+| Test File | Description |
+|-----------|-------------|
+| `test_e2e_topics.py` | Topic listing, subscribing, publishing with real turtlesim |
+| `test_e2e_services.py` | Service calls (spawn, kill, teleport) with real turtlesim |
+| `test_e2e_nodes.py` | Node listing and details from real ROS |
+| `test_e2e_parameters.py` | Parameter get/set/list (ROS 2 specific) |
+| `test_e2e_actions.py` | Action server operations (ROS 2 specific) |
+| `test_e2e_images.py` | Image subscription and processing |
+| `test_e2e_robot_config.py` | ROS version detection and configuration |
+| `test_e2e_integration.py` | Multi-tool workflows |
+| `test_e2e_error_handling.py` | Invalid inputs, connection failures, timeouts |
+| `test_e2e_main.py` | CLI argument parsing, server initialization |
+| `test_e2e_prompts.py` | MCP prompt registration and content |
+| `test_e2e_resources.py` | MCP resource availability |
+
+### Pytest Markers
+
+- `@pytest.mark.e2e` - End-to-end tests requiring ROS environment
+- `@pytest.mark.ros1` - Tests specific to ROS 1
+- `@pytest.mark.ros2` - Tests specific to ROS 2 (e.g., actions, parameters)
 
 ## Prerequisites
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,10 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "ruff",    # single tool for linting & formatting
-    "pytest"   # for tests
+    "ruff",           # single tool for linting & formatting
+    "pytest",         # for tests
+    "pytest-timeout", # test timeouts for E2E tests
+    "pytest-asyncio", # async test support
 ]
 
 [project.scripts]
@@ -61,6 +63,22 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 docstring-code-format = true
+
+# ---------------- Pytest configuration ----------------
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_classes = "Test*"
+python_functions = "test_*"
+addopts = "-v --tb=short"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+markers = [
+    "e2e: end-to-end tests requiring ROS Docker container",
+    "ros1: tests specific to ROS 1",
+    "ros2: tests specific to ROS 2 (actions, parameters)",
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 # MCP Registry validation - required for PyPI package verification
 [tool.mcp]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# ROS MCP Server Tests

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+# End-to-end tests with ROS 2 + turtlesim

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,391 @@
+"""E2E test fixtures for ROS integration tests (ROS 1 and ROS 2)."""
+
+import json
+import os
+import socket
+import time
+
+import pytest
+
+from ros_mcp.utils.websocket import WebSocketManager
+
+
+def pytest_addoption(parser):
+    """Add command line options for ROS version selection."""
+    parser.addoption(
+        "--ros-version",
+        action="store",
+        default="2",
+        choices=["1", "2"],
+        help="ROS version to test against (1 or 2, default: 2)",
+    )
+
+
+def pytest_configure(config):
+    """Configure custom markers."""
+    config.addinivalue_line("markers", "e2e: End-to-end tests requiring ROS environment")
+    config.addinivalue_line("markers", "ros1: Tests specific to ROS 1")
+    config.addinivalue_line("markers", "ros2: Tests specific to ROS 2")
+
+
+@pytest.fixture(scope="session")
+def ros_version(request):
+    """Return the ROS version being tested."""
+    return request.config.getoption("--ros-version")
+
+
+@pytest.fixture(scope="session")
+def rosbridge_host():
+    """Return rosbridge host."""
+    return os.environ.get("ROSBRIDGE_HOST", "127.0.0.1")
+
+
+@pytest.fixture(scope="session")
+def rosbridge_port(ros_version):
+    """Return rosbridge port based on ROS version."""
+    if ros_version == "1":
+        return int(os.environ.get("ROSBRIDGE_PORT", "9091"))
+    return int(os.environ.get("ROSBRIDGE_PORT", "9090"))
+
+
+@pytest.fixture(scope="session")
+def rosbridge_url(rosbridge_host, rosbridge_port):
+    """Return rosbridge WebSocket URL."""
+    return f"ws://{rosbridge_host}:{rosbridge_port}"
+
+
+@pytest.fixture(scope="session")
+def wait_for_rosbridge(rosbridge_host, rosbridge_port):
+    """
+    Wait for rosbridge to be ready (max 60s).
+
+    This fixture blocks until rosbridge is accepting connections.
+    """
+    max_wait = 60
+    for i in range(max_wait):
+        try:
+            sock = socket.create_connection((rosbridge_host, rosbridge_port), timeout=1)
+            sock.close()
+            # Extra buffer for ROS to fully initialize
+            time.sleep(3)
+            return True
+        except (socket.error, ConnectionRefusedError, OSError):
+            time.sleep(1)
+
+    pytest.fail(f"rosbridge not available at {rosbridge_host}:{rosbridge_port} after {max_wait}s")
+
+
+@pytest.fixture
+def ws_manager(wait_for_rosbridge, rosbridge_host, rosbridge_port):
+    """
+    Real WebSocketManager connected to Docker rosbridge.
+
+    This fixture provides a fresh WebSocketManager for each test.
+    The connection is automatically closed after the test.
+    """
+    manager = WebSocketManager(rosbridge_host, rosbridge_port, default_timeout=10.0)
+    yield manager
+    manager.close()
+
+
+@pytest.fixture
+def ws_manager_short_timeout(wait_for_rosbridge, rosbridge_host, rosbridge_port):
+    """WebSocketManager with shorter timeout for faster test failures."""
+    manager = WebSocketManager(rosbridge_host, rosbridge_port, default_timeout=5.0)
+    yield manager
+    manager.close()
+
+
+@pytest.fixture
+def ws_manager_tiny_timeout(wait_for_rosbridge, rosbridge_host, rosbridge_port):
+    """WebSocketManager with very short timeout for testing timeout behavior."""
+    manager = WebSocketManager(rosbridge_host, rosbridge_port, default_timeout=0.5)
+    yield manager
+    manager.close()
+
+
+@pytest.fixture
+def invalid_ws_manager():
+    """WebSocketManager with invalid host for error testing."""
+    manager = WebSocketManager("192.0.2.1", 9090, default_timeout=1.0)  # TEST-NET-1 - guaranteed unreachable
+    yield manager
+    manager.close()
+
+
+# ROS version-aware service types
+@pytest.fixture
+def service_type_empty(ros_version):
+    """Return Empty service type based on ROS version."""
+    if ros_version == "1":
+        return "std_srvs/Empty"
+    return "std_srvs/srv/Empty"
+
+
+@pytest.fixture
+def service_type_teleport(ros_version):
+    """Return TeleportAbsolute service type based on ROS version."""
+    if ros_version == "1":
+        return "turtlesim/TeleportAbsolute"
+    return "turtlesim/srv/TeleportAbsolute"
+
+
+@pytest.fixture
+def service_type_spawn(ros_version):
+    """Return Spawn service type based on ROS version."""
+    if ros_version == "1":
+        return "turtlesim/Spawn"
+    return "turtlesim/srv/Spawn"
+
+
+@pytest.fixture
+def service_type_kill(ros_version):
+    """Return Kill service type based on ROS version."""
+    if ros_version == "1":
+        return "turtlesim/Kill"
+    return "turtlesim/srv/Kill"
+
+
+@pytest.fixture
+def service_type_set_pen(ros_version):
+    """Return SetPen service type based on ROS version."""
+    if ros_version == "1":
+        return "turtlesim/SetPen"
+    return "turtlesim/srv/SetPen"
+
+
+@pytest.fixture
+def msg_type_twist(ros_version):
+    """Return Twist message type based on ROS version."""
+    if ros_version == "1":
+        return "geometry_msgs/Twist"
+    return "geometry_msgs/msg/Twist"
+
+
+@pytest.fixture
+def msg_type_pose(ros_version):
+    """Return Pose message type based on ROS version."""
+    if ros_version == "1":
+        return "turtlesim/Pose"
+    return "turtlesim/msg/Pose"
+
+
+# rosapi service types
+@pytest.fixture
+def rosapi_services_type(ros_version):
+    """Return rosapi Services type based on ROS version."""
+    if ros_version == "1":
+        return "rosapi/Services"
+    return "rosapi_msgs/srv/Services"
+
+
+@pytest.fixture
+def rosapi_topics_type(ros_version):
+    """Return rosapi Topics type based on ROS version."""
+    # Same for both versions
+    return "rosapi/Topics"
+
+
+@pytest.fixture
+def rosapi_nodes_type(ros_version):
+    """Return rosapi Nodes type based on ROS version."""
+    # Same for both versions
+    return "rosapi/Nodes"
+
+
+@pytest.fixture
+def rosapi_node_details_type(ros_version):
+    """Return rosapi NodeDetails type based on ROS version."""
+    # Same for both versions
+    return "rosapi/NodeDetails"
+
+
+@pytest.fixture
+def rosapi_topic_type_type(ros_version):
+    """Return rosapi TopicType type based on ROS version."""
+    # Same for both versions
+    return "rosapi/TopicType"
+
+
+@pytest.fixture
+def rosapi_service_type_type(ros_version):
+    """Return rosapi ServiceType type based on ROS version."""
+    if ros_version == "1":
+        return "rosapi/ServiceType"
+    return "rosapi_msgs/srv/ServiceType"
+
+
+@pytest.fixture
+def rosapi_get_param_type(ros_version):
+    """Return rosapi GetParam type based on ROS version."""
+    if ros_version == "1":
+        return "rosapi/GetParam"
+    return "rosapi_msgs/srv/GetParam"
+
+
+@pytest.fixture
+def rosapi_set_param_type(ros_version):
+    """Return rosapi SetParam type based on ROS version."""
+    if ros_version == "1":
+        return "rosapi/SetParam"
+    return "rosapi_msgs/srv/SetParam"
+
+
+@pytest.fixture
+def rosapi_get_ros_version_type(ros_version):
+    """Return rosapi GetROSVersion type based on ROS version."""
+    if ros_version == "1":
+        # ROS1 doesn't have this service, will skip tests that need it
+        return None
+    return "rosapi_msgs/srv/GetROSVersion"
+
+
+@pytest.fixture
+def turtlesim_topics():
+    """Expected turtlesim topics (same for both ROS versions)."""
+    return [
+        "/turtle1/cmd_vel",
+        "/turtle1/pose",
+        "/turtle1/color_sensor",
+    ]
+
+
+@pytest.fixture
+def turtlesim_services():
+    """Expected turtlesim services (same for both ROS versions)."""
+    return [
+        "/turtle1/teleport_absolute",
+        "/turtle1/teleport_relative",
+        "/turtle1/set_pen",
+        "/spawn",
+        "/kill",
+        "/clear",
+        "/reset",
+    ]
+
+
+@pytest.fixture
+def turtlesim_actions():
+    """Expected turtlesim actions (ROS 2 only)."""
+    return [
+        "/turtle1/rotate_absolute",
+    ]
+
+
+def reset_turtle(ws_manager, service_type="std_srvs/srv/Empty"):
+    """
+    Helper function to reset turtle to center position.
+
+    Args:
+        ws_manager: WebSocketManager instance
+        service_type: Service type string (ROS version dependent)
+    """
+    reset_msg = {
+        "op": "call_service",
+        "service": "/reset",
+        "type": service_type,
+        "args": {},
+        "id": "reset_turtle",
+    }
+
+    with ws_manager:
+        response = ws_manager.request(reset_msg, timeout=5.0)
+
+    # Give time for reset to complete
+    time.sleep(0.5)
+    return response
+
+
+def teleport_turtle(ws_manager, x: float, y: float, theta: float = 0.0,
+                    service_type="turtlesim/srv/TeleportAbsolute"):
+    """
+    Helper function to teleport turtle to specific position.
+
+    Args:
+        ws_manager: WebSocketManager instance
+        x: X coordinate (0.0 to 11.0)
+        y: Y coordinate (0.0 to 11.0)
+        theta: Orientation in radians
+        service_type: Service type string (ROS version dependent)
+    """
+    teleport_msg = {
+        "op": "call_service",
+        "service": "/turtle1/teleport_absolute",
+        "type": service_type,
+        "args": {"x": x, "y": y, "theta": theta},
+        "id": "teleport_turtle",
+    }
+
+    with ws_manager:
+        response = ws_manager.request(teleport_msg, timeout=5.0)
+
+    time.sleep(0.2)
+    return response
+
+
+def get_turtle_pose(ws_manager, timeout: float = 5.0, msg_type="turtlesim/msg/Pose"):
+    """
+    Helper function to get current turtle pose.
+
+    Args:
+        ws_manager: WebSocketManager instance
+        timeout: Timeout in seconds
+        msg_type: Message type string (ROS version dependent)
+
+    Returns:
+        dict with x, y, theta, linear_velocity, angular_velocity
+    """
+    subscribe_msg = {
+        "op": "subscribe",
+        "topic": "/turtle1/pose",
+        "type": msg_type,
+    }
+
+    with ws_manager:
+        ws_manager.send(subscribe_msg)
+
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            response = ws_manager.receive(timeout=0.5)
+            if response:
+                data = json.loads(response)
+                if data.get("op") == "publish" and data.get("topic") == "/turtle1/pose":
+                    # Unsubscribe
+                    ws_manager.send({"op": "unsubscribe", "topic": "/turtle1/pose"})
+                    return data.get("msg", {})
+
+    return None
+
+
+@pytest.fixture
+def reset_turtle_fixture(ws_manager, service_type_empty):
+    """Fixture that resets turtle before each test."""
+    reset_turtle(ws_manager, service_type_empty)
+    yield
+    # Optionally reset after test too
+    reset_turtle(ws_manager, service_type_empty)
+
+
+@pytest.fixture(scope="session")
+def mcp_server(wait_for_rosbridge, rosbridge_host, rosbridge_port):
+    """
+    Full MCP server instance with all tools, resources, and prompts registered.
+
+    This fixture provides access to the configured FastMCP server for testing
+    registration of tools, resources, and prompts.
+    """
+    from fastmcp import FastMCP
+
+    from ros_mcp.prompts import register_all_prompts
+    from ros_mcp.resources import register_all_resources
+    from ros_mcp.tools import register_all_tools
+    from ros_mcp.utils.websocket import WebSocketManager as WsManager
+
+    mcp = FastMCP("ros-mcp-server-test")
+    ws = WsManager(rosbridge_host, rosbridge_port, default_timeout=10.0)
+
+    register_all_tools(mcp, ws, rosbridge_ip=rosbridge_host, rosbridge_port=rosbridge_port)
+    register_all_resources(mcp, ws)
+    register_all_prompts(mcp)
+
+    yield mcp
+    ws.close()

--- a/tests/e2e/docker-compose.e2e.yml
+++ b/tests/e2e/docker-compose.e2e.yml
@@ -1,0 +1,29 @@
+# Docker Compose for E2E tests with ROS 2 Humble turtlesim
+# Usage: docker compose -f tests/e2e/docker-compose.e2e.yml up -d
+
+services:
+  ros2-turtlesim:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.ros2
+    container_name: ros2-turtlesim-e2e
+    environment:
+      - ROS_DISTRO=humble
+      # Disable display for headless testing
+      - QT_QPA_PLATFORM=offscreen
+    ports:
+      - "9090:9090"
+    stdin_open: true
+    tty: true
+    command: >
+      bash -c "source /opt/ros/humble/setup.bash &&
+               ros2 run turtlesim turtlesim_node &
+               sleep 2 &&
+               ros2 run rosapi rosapi_node &
+               ros2 run rosbridge_server rosbridge_websocket"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "source /opt/ros/humble/setup.bash && ros2 topic list | grep -q /turtle1/pose"]
+      interval: 5s
+      timeout: 10s
+      retries: 12
+      start_period: 10s

--- a/tests/e2e/docker-compose.ros1.yml
+++ b/tests/e2e/docker-compose.ros1.yml
@@ -1,0 +1,31 @@
+# Docker Compose for E2E tests with ROS 1 Noetic turtlesim
+# Usage: docker compose -f tests/e2e/docker-compose.ros1.yml up -d
+
+services:
+  ros1-turtlesim:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.ros1
+    container_name: ros1-turtlesim-e2e
+    environment:
+      - ROS_DISTRO=noetic
+      - ROS_MASTER_URI=http://localhost:11311
+      # Disable display for headless testing
+      - QT_QPA_PLATFORM=offscreen
+    ports:
+      - "9091:9091"  # Use different port to allow both ROS1 and ROS2 to run simultaneously
+    stdin_open: true
+    tty: true
+    command: >
+      bash -c "source /opt/ros/noetic/setup.bash &&
+               roscore &
+               sleep 3 &&
+               rosrun turtlesim turtlesim_node &
+               sleep 2 &&
+               roslaunch rosbridge_server rosbridge_websocket.launch port:=9091"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "source /opt/ros/noetic/setup.bash && rostopic list | grep -q /turtle1/pose"]
+      interval: 5s
+      timeout: 10s
+      retries: 12
+      start_period: 15s

--- a/tests/e2e/docker/Dockerfile.ros1
+++ b/tests/e2e/docker/Dockerfile.ros1
@@ -1,0 +1,20 @@
+# ROS1 Noetic with Turtlesim for E2E testing
+FROM osrf/ros:noetic-desktop
+
+ENV ROS_DISTRO=noetic
+SHELL ["/bin/bash", "-c"]
+
+# Install turtlesim and rosbridge packages
+RUN apt-get update && apt-get install -y \
+    ros-noetic-turtlesim \
+    ros-noetic-rosbridge-suite \
+    && rm -rf /var/lib/apt/lists/*
+
+# Auto-source ROS environment in container shell
+RUN echo "source /opt/ros/noetic/setup.bash" >> ~/.bashrc
+
+# Set working directory
+WORKDIR /ros_ws
+
+# Default command to keep container running
+CMD ["/bin/bash"]

--- a/tests/e2e/docker/Dockerfile.ros2
+++ b/tests/e2e/docker/Dockerfile.ros2
@@ -1,0 +1,20 @@
+# ROS2 Humble with Turtlesim for E2E testing
+FROM osrf/ros:humble-desktop
+
+ENV ROS_DISTRO=humble
+SHELL ["/bin/bash", "-c"]
+
+# Install turtlesim and rosbridge packages
+RUN apt-get update && apt-get install -y \
+    ros-humble-turtlesim \
+    ros-humble-rosbridge-suite \
+    && rm -rf /var/lib/apt/lists/*
+
+# Auto-source ROS environment in container shell
+RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
+
+# Set working directory
+WORKDIR /ros2_ws
+
+# Default command to keep container running
+CMD ["/bin/bash"]

--- a/tests/e2e/test_e2e_actions.py
+++ b/tests/e2e/test_e2e_actions.py
@@ -1,0 +1,319 @@
+"""E2E tests for action operations with real ROS 2 turtlesim.
+
+Actions are a ROS 2 specific feature and are not available in ROS 1.
+"""
+
+import json
+import math
+import time
+
+import pytest
+
+from tests.e2e.conftest import get_turtle_pose, reset_turtle, teleport_turtle
+
+# Mark all tests in this module as e2e and ros2-only
+pytestmark = [pytest.mark.e2e, pytest.mark.ros2]
+
+
+class TestGetActions:
+    """E2E tests for get_actions functionality."""
+
+    def test_get_actions_returns_rotate_absolute(self, ws_manager, turtlesim_actions, rosapi_services_type, ros_version):
+        """Verify turtlesim rotate_absolute action exists."""
+        if ros_version == "1":
+            pytest.skip("Actions are not supported in ROS 1")
+
+        # First check if the action_servers service is available
+        services_msg = {
+            "op": "call_service",
+            "service": "/rosapi/services",
+            "type": rosapi_services_type,
+            "args": {},
+            "id": "check_action_servers_service",
+        }
+
+        with ws_manager:
+            services_response = ws_manager.request(services_msg, timeout=10.0)
+
+        services = services_response.get("values", {}).get("services", [])
+
+        if "/rosapi/action_servers" not in services:
+            pytest.skip("action_servers service not available in this rosbridge version")
+
+        # Now get actions
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/action_servers",
+            "type": "rosapi/ActionServers",
+            "args": {},
+            "id": "get_actions_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        if "error" in response:
+            pytest.skip(f"Action listing not supported: {response['error']}")
+
+        actions = response.get("values", {}).get("action_servers", [])
+
+        # Check for expected turtlesim actions
+        for expected_action in turtlesim_actions:
+            assert expected_action in actions, f"Expected {expected_action} in actions"
+
+
+class TestSendRotateAbsoluteGoal:
+    """E2E tests for sending action goals to rotate_absolute."""
+
+    def test_send_rotate_goal_basic(
+        self, ws_manager, service_type_empty, service_type_teleport, msg_type_pose
+    ):
+        """Send a rotation goal and verify it's accepted."""
+        # Reset turtle to known position
+        reset_turtle(ws_manager, service_type_empty)
+        teleport_turtle(ws_manager, 5.5, 5.5, 0.0, service_type_teleport)
+        time.sleep(0.5)
+
+        # Send action goal
+        goal_id = f"test_goal_{int(time.time() * 1000)}"
+        message = {
+            "op": "send_action_goal",
+            "id": goal_id,
+            "action": "/turtle1/rotate_absolute",
+            "action_type": "turtlesim/action/RotateAbsolute",
+            "args": {"theta": math.pi / 2},  # 90 degrees
+            "feedback": True,
+        }
+
+        with ws_manager:
+            ws_manager.send(message)
+
+            # Wait for result or feedback
+            end_time = time.time() + 10.0
+            got_response = False
+
+            while time.time() < end_time:
+                response = ws_manager.receive(timeout=1.0)
+                if response:
+                    data = json.loads(response)
+                    op = data.get("op", "")
+
+                    if op == "action_result":
+                        got_response = True
+                        # Check for success
+                        assert data.get("id") == goal_id
+                        break
+                    elif op == "action_feedback":
+                        # We're receiving feedback, that's good
+                        got_response = True
+                    elif op == "status" and data.get("level") == "error":
+                        pytest.fail(f"Action error: {data.get('msg')}")
+
+        # Verify turtle rotated
+        time.sleep(0.5)
+        pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        if pose and got_response:
+            # Should be approximately 90 degrees (pi/2)
+            expected_theta = math.pi / 2
+            # Allow for some tolerance
+            theta_diff = abs(pose["theta"] - expected_theta)
+            # Handle wrap-around
+            if theta_diff > math.pi:
+                theta_diff = 2 * math.pi - theta_diff
+            assert theta_diff < 0.2, f"Expected theta ~{expected_theta}, got {pose['theta']}"
+
+    def test_send_rotate_goal_with_feedback(self, ws_manager, service_type_empty, service_type_teleport):
+        """Send a rotation goal and verify feedback is received."""
+        reset_turtle(ws_manager, service_type_empty)
+        teleport_turtle(ws_manager, 5.5, 5.5, 0.0, service_type_teleport)
+        time.sleep(0.5)
+
+        goal_id = f"feedback_goal_{int(time.time() * 1000)}"
+        message = {
+            "op": "send_action_goal",
+            "id": goal_id,
+            "action": "/turtle1/rotate_absolute",
+            "action_type": "turtlesim/action/RotateAbsolute",
+            "args": {"theta": math.pi},  # 180 degrees - longer rotation
+            "feedback": True,
+        }
+
+        feedback_received = []
+        result_received = None
+
+        with ws_manager:
+            ws_manager.send(message)
+
+            end_time = time.time() + 15.0
+            while time.time() < end_time:
+                response = ws_manager.receive(timeout=1.0)
+                if response:
+                    data = json.loads(response)
+                    op = data.get("op", "")
+
+                    if op == "action_feedback":
+                        feedback_received.append(data)
+                    elif op == "action_result":
+                        result_received = data
+                        break
+
+        # For a 180 degree rotation, we should get some feedback
+        # (unless the action completes very quickly)
+        if result_received:
+            assert result_received.get("id") == goal_id
+        # Feedback might or might not be received depending on rotation speed
+
+
+class TestCancelActionGoal:
+    """E2E tests for canceling action goals."""
+
+    def test_cancel_action_goal(self, ws_manager, service_type_empty, service_type_teleport):
+        """Start a rotation and cancel it mid-way."""
+        reset_turtle(ws_manager, service_type_empty)
+        teleport_turtle(ws_manager, 5.5, 5.5, 0.0, service_type_teleport)
+        time.sleep(0.5)
+
+        # Start a long rotation
+        goal_id = f"cancel_goal_{int(time.time() * 1000)}"
+        start_message = {
+            "op": "send_action_goal",
+            "id": goal_id,
+            "action": "/turtle1/rotate_absolute",
+            "action_type": "turtlesim/action/RotateAbsolute",
+            "args": {"theta": 2 * math.pi - 0.1},  # Almost full rotation
+            "feedback": True,
+        }
+
+        with ws_manager:
+            ws_manager.send(start_message)
+
+            # Wait a short time then cancel
+            time.sleep(0.5)
+
+            # Send cancel request
+            cancel_message = {
+                "op": "cancel_action_goal",
+                "id": goal_id,
+                "action": "/turtle1/rotate_absolute",
+            }
+            ws_manager.send(cancel_message)
+
+            # Wait for cancellation or result
+            end_time = time.time() + 5.0
+
+            while time.time() < end_time:
+                response = ws_manager.receive(timeout=1.0)
+                if response:
+                    data = json.loads(response)
+                    op = data.get("op", "")
+
+                    if op == "action_result":
+                        # Action completed (might have finished or been cancelled)
+                        break
+                    elif op == "status":
+                        # Might get status about cancellation
+                        if "cancel" in data.get("msg", "").lower():
+                            break
+
+        # Note: Cancel might or might not succeed depending on timing
+        # The important thing is that we can send the cancel request
+
+
+class TestActionStatus:
+    """E2E tests for getting action status."""
+
+    def test_get_action_status_no_active_goals(self, ws_manager, service_type_empty):
+        """Get status when no goals are active."""
+        # Reset to ensure no goals are running
+        reset_turtle(ws_manager, service_type_empty)
+        time.sleep(1.0)
+
+        # Subscribe to action status topic
+        status_topic = "/turtle1/rotate_absolute/_action/status"
+        subscribe_msg = {
+            "op": "subscribe",
+            "topic": status_topic,
+            "type": "action_msgs/msg/GoalStatusArray",
+        }
+
+        with ws_manager:
+            ws_manager.send(subscribe_msg)
+
+            # Try to get a status message
+            end_time = time.time() + 5.0
+            status_received = None
+
+            while time.time() < end_time:
+                response = ws_manager.receive(timeout=1.0)
+                if response:
+                    data = json.loads(response)
+                    if data.get("op") == "publish" and data.get("topic") == status_topic:
+                        status_received = data.get("msg", {})
+                        break
+
+            ws_manager.send({"op": "unsubscribe", "topic": status_topic})
+
+        # Status message might have empty or non-empty status_list
+        if status_received is not None:
+            assert "status_list" in status_received
+
+
+class TestActionIntegration:
+    """Integration tests for action workflows."""
+
+    def test_rotate_then_check_pose(
+        self, ws_manager, service_type_empty, service_type_teleport, msg_type_pose
+    ):
+        """Complete workflow: rotate and verify final position."""
+        # Setup
+        reset_turtle(ws_manager, service_type_empty)
+        teleport_turtle(ws_manager, 5.5, 5.5, 0.0, service_type_teleport)
+        time.sleep(0.5)
+
+        initial_pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        assert initial_pose is not None
+        assert abs(initial_pose["theta"]) < 0.1, "Should start at theta ~0"
+
+        # Rotate to 90 degrees
+        target_theta = math.pi / 2
+        goal_id = f"integration_goal_{int(time.time() * 1000)}"
+
+        message = {
+            "op": "send_action_goal",
+            "id": goal_id,
+            "action": "/turtle1/rotate_absolute",
+            "action_type": "turtlesim/action/RotateAbsolute",
+            "args": {"theta": target_theta},
+            "feedback": True,
+        }
+
+        with ws_manager:
+            ws_manager.send(message)
+
+            # Wait for completion
+            end_time = time.time() + 10.0
+            completed = False
+
+            while time.time() < end_time:
+                response = ws_manager.receive(timeout=1.0)
+                if response:
+                    data = json.loads(response)
+                    if data.get("op") == "action_result":
+                        completed = True
+                        break
+
+        # Verify final pose
+        time.sleep(0.5)
+        final_pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        assert final_pose is not None
+
+        if completed:
+            # Should be at target theta
+            theta_diff = abs(final_pose["theta"] - target_theta)
+            if theta_diff > math.pi:
+                theta_diff = 2 * math.pi - theta_diff
+            assert theta_diff < 0.2, f"Expected theta ~{target_theta}, got {final_pose['theta']}"
+
+            # Position should not have changed significantly
+            assert abs(final_pose["x"] - 5.5) < 0.5
+            assert abs(final_pose["y"] - 5.5) < 0.5

--- a/tests/e2e/test_e2e_error_handling.py
+++ b/tests/e2e/test_e2e_error_handling.py
@@ -1,0 +1,226 @@
+"""E2E tests for error handling and edge cases."""
+
+import json
+import time
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+class TestConnectionErrors:
+    """E2E tests for connection error handling."""
+
+    def test_connection_timeout_to_invalid_host(self, invalid_ws_manager):
+        """Test connection timeout to unreachable host."""
+        # Try to connect to invalid host
+        error = invalid_ws_manager.connect()
+
+        # Should return an error
+        assert error is not None, "Expected connection error for invalid host"
+        assert "error" in error.lower() or "timeout" in error.lower() or "connection" in error.lower(), (
+            f"Expected connection or timeout error, got: {error}"
+        )
+
+    def test_send_without_connection(self, invalid_ws_manager):
+        """Test sending message without valid connection."""
+        message = {"op": "call_service", "service": "/test", "args": {}}
+
+        # Send should fail or return error
+        result = invalid_ws_manager.send(message)
+
+        # Should return error string
+        assert result is not None, "Expected error when sending without connection"
+
+
+class TestSubscriptionErrors:
+    """E2E tests for subscription error handling."""
+
+    def test_subscribe_timeout_on_inactive_topic(self, ws_manager_tiny_timeout):
+        """Test subscription timeout on topic that doesn't publish."""
+        # Create a topic name that likely doesn't exist or publish
+        fake_topic = "/nonexistent_topic_12345"
+
+        subscribe_msg = {
+            "op": "subscribe",
+            "topic": fake_topic,
+            "type": "std_msgs/msg/String",
+        }
+
+        with ws_manager_tiny_timeout:
+            ws_manager_tiny_timeout.send(subscribe_msg)
+
+            # Should timeout waiting for message
+            start = time.time()
+            response = ws_manager_tiny_timeout.receive(timeout=1.0)
+            elapsed = time.time() - start
+
+            # Unsubscribe
+            ws_manager_tiny_timeout.send({"op": "unsubscribe", "topic": fake_topic})
+
+        # Should have timed out (no message received from nonexistent topic)
+        # Response might be None (timeout) or an error status
+        if response:
+            data = json.loads(response)
+            # If we got a response, it should be an error or not from our fake topic
+            assert data.get("topic") != fake_topic or data.get("op") == "status"
+
+
+class TestServiceCallErrors:
+    """E2E tests for service call error handling."""
+
+    def test_service_call_timeout(self, ws_manager_short_timeout, rosapi_topics_type):
+        """Test service call with short timeout."""
+        # This test verifies the timeout mechanism works
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/topics",
+            "type": rosapi_topics_type,
+            "args": {},
+            "id": "timeout_test",
+        }
+
+        with ws_manager_short_timeout:
+            response = ws_manager_short_timeout.request(message, timeout=5.0)
+
+        # With valid rosbridge, this should succeed
+        assert "values" in response or "error" in response, (
+            f"Expected valid response or error: {response}"
+        )
+
+    def test_call_nonexistent_service(self, ws_manager, service_type_empty):
+        """Test calling a service that doesn't exist."""
+        message = {
+            "op": "call_service",
+            "service": "/nonexistent_service_12345",
+            "type": service_type_empty,
+            "args": {},
+            "id": "nonexistent_service_test",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=5.0)
+
+        # Should return an error or failed result
+        # rosbridge may return different error formats
+        is_error = (
+            "error" in response
+            or response.get("result") is False
+            or "error" in str(response).lower()
+        )
+        assert is_error or response.get("values") is None, (
+            f"Expected error for nonexistent service: {response}"
+        )
+
+    def test_malformed_service_request(self, ws_manager):
+        """Test service call with malformed request."""
+        # Missing required fields
+        message = {
+            "op": "call_service",
+            # Missing service name and type
+            "args": {},
+            "id": "malformed_test",
+        }
+
+        with ws_manager:
+            ws_manager.send(message)
+            response = ws_manager.receive(timeout=3.0)
+
+        # Should get an error response or no valid response
+        if response:
+            data = json.loads(response)
+            # rosbridge should return an error status
+            is_error = (
+                data.get("op") == "status"
+                or "error" in str(data).lower()
+            )
+            # Malformed requests may be silently ignored or return error
+            assert is_error or data.get("op") != "service_response"
+
+
+class TestWebSocketReconnection:
+    """E2E tests for WebSocket reconnection behavior."""
+
+    def test_websocket_reconnection_after_close(self, ws_manager, rosapi_topics_type):
+        """Test WebSocket reconnects after manual close."""
+        # First connection and request
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/topics",
+            "type": rosapi_topics_type,
+            "args": {},
+            "id": "reconnect_test_1",
+        }
+
+        with ws_manager:
+            response1 = ws_manager.request(message, timeout=5.0)
+
+        assert "values" in response1, f"First request failed: {response1}"
+
+        # Close the connection
+        ws_manager.close()
+
+        # Second request should reconnect automatically
+        message["id"] = "reconnect_test_2"
+
+        with ws_manager:
+            response2 = ws_manager.request(message, timeout=5.0)
+
+        assert "values" in response2, f"Second request after reconnect failed: {response2}"
+
+    def test_multiple_sequential_requests(self, ws_manager, rosapi_topics_type):
+        """Test multiple sequential requests on same connection."""
+        for i in range(3):
+            message = {
+                "op": "call_service",
+                "service": "/rosapi/topics",
+                "type": rosapi_topics_type,
+                "args": {},
+                "id": f"sequential_test_{i}",
+            }
+
+            with ws_manager:
+                response = ws_manager.request(message, timeout=5.0)
+
+            assert "values" in response, f"Request {i} failed: {response}"
+
+
+class TestInputValidation:
+    """E2E tests for input validation error handling."""
+
+    def test_empty_topic_name_handling(self, ws_manager):
+        """Test handling of empty topic name in subscription."""
+        subscribe_msg = {
+            "op": "subscribe",
+            "topic": "",
+            "type": "std_msgs/msg/String",
+        }
+
+        with ws_manager:
+            ws_manager.send(subscribe_msg)
+            response = ws_manager.receive(timeout=2.0)
+
+        # Should get error or be ignored
+        if response:
+            data = json.loads(response)
+            # Empty topic should not return valid publish message
+            assert data.get("op") != "publish" or data.get("topic") != ""
+
+    def test_invalid_message_type_handling(self, ws_manager, rosapi_topic_type_type):
+        """Test handling of invalid message type."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/topic_type",
+            "type": rosapi_topic_type_type,
+            "args": {"topic": "/nonexistent_topic_xyz"},
+            "id": "invalid_type_test",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=5.0)
+
+        # Should return empty type or error for nonexistent topic
+        if "values" in response:
+            topic_type = response["values"].get("type", "")
+            # Empty type indicates topic doesn't exist
+            assert topic_type == "" or "error" in str(response).lower()

--- a/tests/e2e/test_e2e_images.py
+++ b/tests/e2e/test_e2e_images.py
@@ -1,0 +1,264 @@
+"""E2E tests for image processing functionality."""
+
+import base64
+import json
+import os
+import tempfile
+
+import pytest
+
+from ros_mcp.utils.websocket import is_image_like, parse_image
+
+pytestmark = pytest.mark.e2e
+
+
+class TestImageDetection:
+    """E2E tests for image detection functions."""
+
+    def test_is_image_like_raw_image(self):
+        """Test is_image_like correctly identifies raw image messages."""
+        raw_image_msg = {
+            "data": "SGVsbG8gV29ybGQ=",  # base64 encoded data
+            "width": 640,
+            "height": 480,
+            "encoding": "rgb8",
+            "step": 1920,  # width * 3 for rgb8
+        }
+
+        assert is_image_like(raw_image_msg) is True, "Should detect raw image message"
+
+    def test_is_image_like_compressed_image(self):
+        """Test is_image_like correctly identifies compressed image messages."""
+        compressed_image_msg = {
+            "data": "SGVsbG8gV29ybGQ=",  # base64 encoded data
+            "format": "jpeg",
+        }
+
+        assert is_image_like(compressed_image_msg) is True, "Should detect compressed image message"
+
+    def test_is_image_like_non_image(self):
+        """Test is_image_like correctly rejects non-image messages."""
+        # Point cloud message (has data but is not image)
+        pointcloud_msg = {
+            "data": "SGVsbG8gV29ybGQ=",
+            "width": 640,
+            "height": 1,
+            "fields": [{"name": "x", "offset": 0, "datatype": 7, "count": 1}],
+        }
+
+        assert is_image_like(pointcloud_msg) is False, "Should not detect point cloud as image"
+
+        # Simple string message
+        string_msg = {"data": "Hello World"}
+
+        assert is_image_like(string_msg) is False, "Should not detect string as image"
+
+    def test_is_image_like_bgr8_encoding(self):
+        """Test is_image_like with bgr8 encoding."""
+        bgr_image_msg = {
+            "data": "SGVsbG8gV29ybGQ=",
+            "width": 320,
+            "height": 240,
+            "encoding": "bgr8",
+            "step": 960,
+        }
+
+        assert is_image_like(bgr_image_msg) is True, "Should detect bgr8 image"
+
+    def test_is_image_like_mono8_encoding(self):
+        """Test is_image_like with mono8 encoding."""
+        mono_image_msg = {
+            "data": "SGVsbG8gV29ybGQ=",
+            "width": 100,
+            "height": 100,
+            "encoding": "mono8",
+            "step": 100,
+        }
+
+        assert is_image_like(mono_image_msg) is True, "Should detect mono8 image"
+
+    def test_is_image_like_invalid_encoding(self):
+        """Test is_image_like with invalid encoding."""
+        invalid_image_msg = {
+            "data": "SGVsbG8gV29ybGQ=",
+            "width": 100,
+            "height": 100,
+            "encoding": "invalid_encoding",
+            "step": 100,
+        }
+
+        assert is_image_like(invalid_image_msg) is False, "Should reject invalid encoding"
+
+    def test_is_image_like_missing_fields(self):
+        """Test is_image_like with missing required fields."""
+        # Missing width
+        incomplete_msg = {
+            "data": "SGVsbG8gV29ybGQ=",
+            "height": 480,
+            "encoding": "rgb8",
+        }
+
+        assert is_image_like(incomplete_msg) is False, "Should reject message missing width"
+
+    def test_is_image_like_non_dict(self):
+        """Test is_image_like with non-dict input."""
+        assert is_image_like("not a dict") is False
+        assert is_image_like(None) is False
+        assert is_image_like([1, 2, 3]) is False
+
+
+class TestImageParsing:
+    """E2E tests for image parsing functions."""
+
+    def test_parse_raw_rgb8_image(self):
+        """Test parsing a raw RGB8 image message."""
+        # Create a small 2x2 RGB image
+        # Red, Green, Blue, White pixels
+        pixels = bytes([
+            255, 0, 0,    # Red
+            0, 255, 0,    # Green
+            0, 0, 255,    # Blue
+            255, 255, 255 # White
+        ])
+        data_b64 = base64.b64encode(pixels).decode('utf-8')
+
+        raw_message = json.dumps({
+            "op": "publish",
+            "topic": "/camera/image_raw",
+            "msg": {
+                "data": data_b64,
+                "width": 2,
+                "height": 2,
+                "encoding": "rgb8",
+                "step": 6,
+                "header": {"stamp": {"sec": 0, "nanosec": 0}, "frame_id": "camera"},
+            }
+        })
+
+        # Parse the image
+        result = parse_image(raw_message)
+
+        # Should succeed and save image
+        assert result is not None, "Should successfully parse RGB8 image"
+        assert os.path.exists("./camera/received_image.jpeg"), "Image file should be created"
+
+        # Cleanup
+        if os.path.exists("./camera/received_image.jpeg"):
+            os.remove("./camera/received_image.jpeg")
+
+    def test_parse_compressed_jpeg_image(self):
+        """Test parsing a compressed JPEG image message."""
+        # Create a minimal valid JPEG (1x1 pixel)
+        # This is a minimal valid JPEG file bytes
+        minimal_jpeg = bytes([
+            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+            0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xDB, 0x00, 0x43,
+            0x00, 0x08, 0x06, 0x06, 0x07, 0x06, 0x05, 0x08, 0x07, 0x07, 0x07, 0x09,
+            0x09, 0x08, 0x0A, 0x0C, 0x14, 0x0D, 0x0C, 0x0B, 0x0B, 0x0C, 0x19, 0x12,
+            0x13, 0x0F, 0x14, 0x1D, 0x1A, 0x1F, 0x1E, 0x1D, 0x1A, 0x1C, 0x1C, 0x20,
+            0x24, 0x2E, 0x27, 0x20, 0x22, 0x2C, 0x23, 0x1C, 0x1C, 0x28, 0x37, 0x29,
+            0x2C, 0x30, 0x31, 0x34, 0x34, 0x34, 0x1F, 0x27, 0x39, 0x3D, 0x38, 0x32,
+            0x3C, 0x2E, 0x33, 0x34, 0x32, 0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x00, 0x01,
+            0x00, 0x01, 0x01, 0x01, 0x11, 0x00, 0xFF, 0xC4, 0x00, 0x1F, 0x00, 0x00,
+            0x01, 0x05, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0A, 0x0B, 0xFF, 0xC4, 0x00, 0xB5, 0x10, 0x00, 0x02, 0x01, 0x03,
+            0x03, 0x02, 0x04, 0x03, 0x05, 0x05, 0x04, 0x04, 0x00, 0x00, 0x01, 0x7D,
+            0x01, 0x02, 0x03, 0x00, 0x04, 0x11, 0x05, 0x12, 0x21, 0x31, 0x41, 0x06,
+            0x13, 0x51, 0x61, 0x07, 0x22, 0x71, 0x14, 0x32, 0x81, 0x91, 0xA1, 0x08,
+            0x23, 0x42, 0xB1, 0xC1, 0x15, 0x52, 0xD1, 0xF0, 0x24, 0x33, 0x62, 0x72,
+            0x82, 0x09, 0x0A, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x25, 0x26, 0x27, 0x28,
+            0x29, 0x2A, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x43, 0x44, 0x45,
+            0x46, 0x47, 0x48, 0x49, 0x4A, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59,
+            0x5A, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x73, 0x74, 0x75,
+            0x76, 0x77, 0x78, 0x79, 0x7A, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89,
+            0x8A, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9A, 0xA2, 0xA3,
+            0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6,
+            0xB7, 0xB8, 0xB9, 0xBA, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9,
+            0xCA, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xE1, 0xE2,
+            0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xF1, 0xF2, 0xF3, 0xF4,
+            0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01,
+            0x00, 0x00, 0x3F, 0x00, 0xFB, 0xD5, 0xDB, 0x00, 0x31, 0xC4, 0x1F, 0xFF,
+            0xD9
+        ])
+        data_b64 = base64.b64encode(minimal_jpeg).decode('utf-8')
+
+        compressed_message = json.dumps({
+            "op": "publish",
+            "topic": "/camera/image_compressed",
+            "msg": {
+                "data": data_b64,
+                "format": "jpeg",
+                "header": {"stamp": {"sec": 0, "nanosec": 0}, "frame_id": "camera"},
+            }
+        })
+
+        # Parse the image
+        result = parse_image(compressed_message)
+
+        # Should succeed and save image
+        assert result is not None, "Should successfully parse compressed JPEG image"
+        assert os.path.exists("./camera/received_image.jpeg"), "Image file should be created"
+
+        # Cleanup
+        if os.path.exists("./camera/received_image.jpeg"):
+            os.remove("./camera/received_image.jpeg")
+
+    def test_parse_image_invalid_json(self):
+        """Test parse_image with invalid JSON."""
+        result = parse_image("not valid json")
+
+        assert result is None, "Should return None for invalid JSON"
+
+    def test_parse_image_missing_msg_field(self):
+        """Test parse_image with missing msg field."""
+        message = json.dumps({"op": "publish", "topic": "/test"})
+
+        result = parse_image(message)
+
+        assert result is None, "Should return None for missing msg field"
+
+    def test_parse_image_missing_data_field(self):
+        """Test parse_image with missing data field."""
+        message = json.dumps({
+            "op": "publish",
+            "topic": "/camera/image_raw",
+            "msg": {
+                "width": 640,
+                "height": 480,
+                "encoding": "rgb8",
+            }
+        })
+
+        result = parse_image(message)
+
+        assert result is None, "Should return None for missing data field"
+
+
+class TestImageToolIntegration:
+    """E2E tests for image tool integration."""
+
+    def test_analyze_previously_received_image_no_file(self):
+        """Test analyze tool when no image file exists."""
+        from ros_mcp.tools.images import register_image_tools
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("test-image")
+        register_image_tools(mcp)
+
+        # Get the registered tool
+        tool_manager = mcp._tool_manager
+        tools = tool_manager._tools
+
+        assert "analyze_previously_received_image" in tools, (
+            "analyze_previously_received_image tool should be registered"
+        )
+
+    def test_image_tool_registration(self, mcp_server):
+        """Test that image tools are properly registered."""
+        tool_manager = mcp_server._tool_manager
+        tools = tool_manager._tools
+
+        assert "analyze_previously_received_image" in tools, (
+            "analyze_previously_received_image should be registered with MCP server"
+        )

--- a/tests/e2e/test_e2e_integration.py
+++ b/tests/e2e/test_e2e_integration.py
@@ -1,0 +1,308 @@
+"""E2E integration tests for multi-tool workflows."""
+
+import json
+import time
+
+import pytest
+
+from tests.e2e.conftest import get_turtle_pose, reset_turtle, teleport_turtle
+
+pytestmark = pytest.mark.e2e
+
+
+class TestDiscoverAndSubscribe:
+    """E2E tests for discover-then-subscribe workflows."""
+
+    def test_discover_topics_then_subscribe(self, ws_manager, rosapi_topics_type, msg_type_pose):
+        """Test workflow: discover topics, then subscribe to one."""
+        # Step 1: Discover topics
+        topics_message = {
+            "op": "call_service",
+            "service": "/rosapi/topics",
+            "type": rosapi_topics_type,
+            "args": {},
+            "id": "discover_topics",
+        }
+
+        with ws_manager:
+            topics_response = ws_manager.request(topics_message, timeout=10.0)
+
+        assert "values" in topics_response
+        topics = topics_response["values"].get("topics", [])
+        assert "/turtle1/pose" in topics, "Expected /turtle1/pose topic"
+
+        # Step 2: Subscribe to the discovered topic
+        subscribe_message = {
+            "op": "subscribe",
+            "topic": "/turtle1/pose",
+            "type": msg_type_pose,
+        }
+
+        with ws_manager:
+            ws_manager.send(subscribe_message)
+
+            # Wait for message
+            end_time = time.time() + 5.0
+            received = False
+            while time.time() < end_time:
+                response = ws_manager.receive(timeout=0.5)
+                if response:
+                    data = json.loads(response)
+                    if data.get("op") == "publish" and data.get("topic") == "/turtle1/pose":
+                        received = True
+                        msg = data.get("msg", {})
+                        assert "x" in msg, "Expected x in pose message"
+                        assert "y" in msg, "Expected y in pose message"
+                        break
+
+            # Unsubscribe
+            ws_manager.send({"op": "unsubscribe", "topic": "/turtle1/pose"})
+
+        assert received, "Did not receive message from subscribed topic"
+
+    def test_discover_services_then_call(self, ws_manager, rosapi_services_type, service_type_empty):
+        """Test workflow: discover services, then call one."""
+        # Step 1: Discover services
+        services_message = {
+            "op": "call_service",
+            "service": "/rosapi/services",
+            "type": rosapi_services_type,
+            "args": {},
+            "id": "discover_services",
+        }
+
+        with ws_manager:
+            services_response = ws_manager.request(services_message, timeout=10.0)
+
+        assert "values" in services_response
+        services = services_response["values"].get("services", [])
+        assert "/reset" in services, "Expected /reset service"
+
+        # Step 2: Call the discovered service
+        call_message = {
+            "op": "call_service",
+            "service": "/reset",
+            "type": service_type_empty,
+            "args": {},
+            "id": "call_reset",
+        }
+
+        with ws_manager:
+            call_response = ws_manager.request(call_message, timeout=10.0)
+
+        # Reset service should succeed (result may be empty for Empty srv)
+        assert "error" not in call_response or call_response.get("result") is not None
+
+
+class TestTurtleControlWorkflow:
+    """E2E tests for turtle control workflows."""
+
+    def test_spawn_turtle_control_kill(
+        self, ws_manager, service_type_spawn, service_type_kill, msg_type_twist
+    ):
+        """Test workflow: spawn turtle, control it, then kill it."""
+        # Step 1: Spawn a new turtle
+        spawn_message = {
+            "op": "call_service",
+            "service": "/spawn",
+            "type": service_type_spawn,
+            "args": {"x": 5.0, "y": 5.0, "theta": 0.0, "name": "test_turtle"},
+            "id": "spawn_turtle",
+        }
+
+        with ws_manager:
+            spawn_response = ws_manager.request(spawn_message, timeout=10.0)
+
+        # Note: Spawn might fail if turtle already exists, which is okay
+        spawned = "values" in spawn_response or "error" not in spawn_response
+
+        # Step 2: Try to move the turtle (publish velocity)
+        if spawned:
+            advertise_msg = {
+                "op": "advertise",
+                "topic": "/test_turtle/cmd_vel",
+                "type": msg_type_twist,
+            }
+
+            publish_msg = {
+                "op": "publish",
+                "topic": "/test_turtle/cmd_vel",
+                "msg": {"linear": {"x": 1.0, "y": 0.0, "z": 0.0}, "angular": {"x": 0.0, "y": 0.0, "z": 0.5}},
+            }
+
+            with ws_manager:
+                ws_manager.send(advertise_msg)
+                time.sleep(0.1)
+                ws_manager.send(publish_msg)
+                time.sleep(0.5)
+                ws_manager.send({"op": "unadvertise", "topic": "/test_turtle/cmd_vel"})
+
+        # Step 3: Kill the turtle
+        kill_message = {
+            "op": "call_service",
+            "service": "/kill",
+            "type": service_type_kill,
+            "args": {"name": "test_turtle"},
+            "id": "kill_turtle",
+        }
+
+        with ws_manager:
+            ws_manager.request(kill_message, timeout=10.0)
+
+        # Kill should succeed (or turtle didn't exist)
+        # Both are acceptable outcomes for this test
+
+
+class TestRapidOperations:
+    """E2E tests for rapid sequential operations."""
+
+    def test_rapid_sequential_topic_subscriptions(self, ws_manager, msg_type_pose):
+        """Test rapid subscribe/unsubscribe cycles."""
+        topic = "/turtle1/pose"
+
+        for i in range(5):
+            subscribe_msg = {
+                "op": "subscribe",
+                "topic": topic,
+                "type": msg_type_pose,
+                "id": f"rapid_sub_{i}",
+            }
+
+            with ws_manager:
+                ws_manager.send(subscribe_msg)
+
+                # Wait briefly for a message
+                response = ws_manager.receive(timeout=1.0)
+                if response:
+                    data = json.loads(response)
+                    if data.get("op") == "publish":
+                        assert data.get("topic") == topic
+
+                # Unsubscribe
+                ws_manager.send({"op": "unsubscribe", "topic": topic})
+
+            time.sleep(0.1)  # Brief pause between cycles
+
+    def test_rapid_service_calls(self, ws_manager, rosapi_topics_type):
+        """Test rapid service call sequences."""
+        for i in range(5):
+            message = {
+                "op": "call_service",
+                "service": "/rosapi/topics",
+                "type": rosapi_topics_type,
+                "args": {},
+                "id": f"rapid_call_{i}",
+            }
+
+            with ws_manager:
+                response = ws_manager.request(message, timeout=5.0)
+
+            assert "values" in response, f"Call {i} failed: {response}"
+            time.sleep(0.1)  # Brief pause between calls
+
+
+class TestPublishSubscribeRoundtrip:
+    """E2E tests for publish-subscribe roundtrip."""
+
+    def test_publish_subscribe_roundtrip(
+        self, ws_manager, reset_turtle_fixture, msg_type_twist, msg_type_pose
+    ):
+        """Test publishing to cmd_vel and observing pose change."""
+        # Get initial pose
+        initial_pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        assert initial_pose is not None, "Could not get initial pose"
+        initial_x = initial_pose.get("x", 0)
+
+        # Publish velocity command to move forward
+        with ws_manager:
+            ws_manager.send({
+                "op": "advertise",
+                "topic": "/turtle1/cmd_vel",
+                "type": msg_type_twist,
+            })
+            time.sleep(0.1)
+
+            # Publish forward movement
+            ws_manager.send({
+                "op": "publish",
+                "topic": "/turtle1/cmd_vel",
+                "msg": {"linear": {"x": 2.0, "y": 0.0, "z": 0.0}, "angular": {"x": 0.0, "y": 0.0, "z": 0.0}},
+            })
+            time.sleep(0.5)  # Let turtle move
+
+            ws_manager.send({"op": "unadvertise", "topic": "/turtle1/cmd_vel"})
+
+        # Get new pose
+        new_pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        assert new_pose is not None, "Could not get new pose"
+        new_x = new_pose.get("x", 0)
+
+        # Turtle should have moved forward (x increased)
+        assert new_x > initial_x, f"Turtle should have moved: initial_x={initial_x}, new_x={new_x}"
+
+
+class TestFullDiscoveryWorkflow:
+    """E2E tests for full robot discovery workflow."""
+
+    def test_full_robot_discovery_workflow(
+        self, ws_manager, rosapi_nodes_type, rosapi_topics_type, rosapi_services_type
+    ):
+        """Test complete discovery workflow: nodes -> topics -> services."""
+        # Step 1: Discover nodes
+        nodes_message = {
+            "op": "call_service",
+            "service": "/rosapi/nodes",
+            "type": rosapi_nodes_type,
+            "args": {},
+            "id": "discover_nodes",
+        }
+
+        with ws_manager:
+            nodes_response = ws_manager.request(nodes_message, timeout=10.0)
+
+        assert "values" in nodes_response, f"Failed to get nodes: {nodes_response}"
+        nodes = nodes_response["values"].get("nodes", [])
+        assert len(nodes) > 0, "Expected at least one node"
+
+        # Step 2: Discover topics
+        topics_message = {
+            "op": "call_service",
+            "service": "/rosapi/topics",
+            "type": rosapi_topics_type,
+            "args": {},
+            "id": "discover_topics",
+        }
+
+        with ws_manager:
+            topics_response = ws_manager.request(topics_message, timeout=10.0)
+
+        assert "values" in topics_response
+        topics = topics_response["values"].get("topics", [])
+        types = topics_response["values"].get("types", [])
+        assert len(topics) > 0, "Expected at least one topic"
+        assert len(topics) == len(types), "Topics and types should have same length"
+
+        # Step 3: Discover services
+        services_message = {
+            "op": "call_service",
+            "service": "/rosapi/services",
+            "type": rosapi_services_type,
+            "args": {},
+            "id": "discover_services",
+        }
+
+        with ws_manager:
+            services_response = ws_manager.request(services_message, timeout=10.0)
+
+        assert "values" in services_response
+        services = services_response["values"].get("services", [])
+        assert len(services) > 0, "Expected at least one service"
+
+        # Step 4: Verify turtlesim presence
+        turtlesim_nodes = [n for n in nodes if "turtle" in n.lower()]
+        turtlesim_topics = [t for t in topics if "turtle" in t.lower()]
+        turtlesim_services = [s for s in services if "turtle" in s.lower()]
+
+        assert len(turtlesim_nodes) > 0 or len(turtlesim_topics) > 0 or len(turtlesim_services) > 0, (
+            "Expected turtlesim to be present in the ROS system"
+        )

--- a/tests/e2e/test_e2e_main.py
+++ b/tests/e2e/test_e2e_main.py
@@ -1,0 +1,169 @@
+"""E2E tests for CLI argument parsing and server initialization."""
+
+import argparse
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+class TestParseArguments:
+    """E2E tests for command line argument parsing."""
+
+    def test_parse_arguments_defaults(self):
+        """Verify default argument values are correct."""
+        from ros_mcp.main import parse_arguments
+
+        # Mock sys.argv to test defaults
+        import sys
+        original_argv = sys.argv
+        try:
+            sys.argv = ["ros_mcp"]
+            args = parse_arguments()
+
+            assert args.transport == "stdio", "Default transport should be stdio"
+            assert args.host == "127.0.0.1", "Default host should be 127.0.0.1"
+            assert args.port == 9000, "Default port should be 9000"
+        finally:
+            sys.argv = original_argv
+
+    def test_parse_arguments_http_transport(self):
+        """Verify HTTP transport arguments are parsed correctly."""
+        from ros_mcp.main import parse_arguments
+
+        import sys
+        original_argv = sys.argv
+        try:
+            sys.argv = [
+                "ros_mcp",
+                "--transport", "http",
+                "--host", "0.0.0.0",
+                "--port", "8080",
+            ]
+            args = parse_arguments()
+
+            assert args.transport == "http", "Transport should be http"
+            assert args.host == "0.0.0.0", "Host should be 0.0.0.0"
+            assert args.port == 8080, "Port should be 8080"
+        finally:
+            sys.argv = original_argv
+
+    def test_parse_arguments_streamable_http_transport(self):
+        """Verify streamable-http transport arguments are parsed correctly."""
+        from ros_mcp.main import parse_arguments
+
+        import sys
+        original_argv = sys.argv
+        try:
+            sys.argv = [
+                "ros_mcp",
+                "--transport", "streamable-http",
+                "--host", "192.168.1.100",
+                "--port", "9999",
+            ]
+            args = parse_arguments()
+
+            assert args.transport == "streamable-http"
+            assert args.host == "192.168.1.100"
+            assert args.port == 9999
+        finally:
+            sys.argv = original_argv
+
+
+class TestMCPServerRegistration:
+    """E2E tests for MCP server component registration."""
+
+    def test_mcp_server_has_all_tools_registered(self, mcp_server):
+        """Verify all expected tools are registered with MCP server."""
+        tool_manager = mcp_server._tool_manager
+        tools = tool_manager._tools
+
+        # Expected tool categories based on the project structure
+        expected_tools = [
+            # Connection tools
+            "connect_to_robot",
+            "detect_ros_version",
+            # Topic tools
+            "get_topics",
+            "get_topic_type",
+            "get_topic_details",
+            "get_message_details",
+            "subscribe_once",
+            "subscribe_for_duration",
+            "publish_once",
+            "publish_for_durations",
+            # Service tools
+            "get_services",
+            "get_service_type",
+            "get_service_details",
+            "call_service",
+            # Node tools
+            "get_nodes",
+            "get_node_details",
+            # Parameter tools
+            "get_parameter",
+            "set_parameter",
+            "has_parameter",
+            "delete_parameter",
+            "get_parameters",
+            "get_parameter_details",
+            # Action tools
+            "get_actions",
+            "get_action_details",
+            "get_action_status",
+            "send_action_goal",
+            "cancel_action_goal",
+            # Image tools
+            "analyze_previously_received_image",
+        ]
+
+        tool_names = list(tools.keys())
+        for expected_tool in expected_tools:
+            assert expected_tool in tool_names, (
+                f"Expected tool '{expected_tool}' to be registered. Found: {tool_names}"
+            )
+
+    def test_mcp_server_has_all_resources_registered(self, mcp_server):
+        """Verify all expected resources are registered with MCP server."""
+        resource_manager = mcp_server._resource_manager
+        resources = resource_manager._resources
+
+        expected_resources = [
+            "ros-mcp://robot-specs/get_verified_robots_list",
+            "ros-mcp://ros-metadata/topics/all",
+            "ros-mcp://ros-metadata/services/all",
+            "ros-mcp://ros-metadata/nodes/all",
+        ]
+
+        for expected_resource in expected_resources:
+            assert expected_resource in resources, (
+                f"Expected resource '{expected_resource}' to be registered"
+            )
+
+    def test_mcp_server_has_all_prompts_registered(self, mcp_server):
+        """Verify all expected prompts are registered with MCP server."""
+        prompt_manager = mcp_server._prompt_manager
+        prompts = prompt_manager._prompts
+
+        expected_prompts = [
+            "test-server-tools",
+            "test-connection-tools",
+            "test-nodes-tools",
+            "test-services-tools",
+            "test-topics-tools",
+            "test-actions-tools",
+            "test-parameters-tools",
+        ]
+
+        prompt_names = list(prompts.keys())
+        for expected_prompt in expected_prompts:
+            assert expected_prompt in prompt_names, (
+                f"Expected prompt '{expected_prompt}' to be registered"
+            )
+
+    def test_mcp_server_name(self, mcp_server):
+        """Verify MCP server has correct name."""
+        # The test server is named differently for isolation
+        assert "ros-mcp-server" in mcp_server.name, (
+            f"Expected 'ros-mcp-server' in name, got: {mcp_server.name}"
+        )

--- a/tests/e2e/test_e2e_nodes.py
+++ b/tests/e2e/test_e2e_nodes.py
@@ -1,0 +1,202 @@
+"""E2E tests for node operations with real ROS turtlesim."""
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+class TestGetNodes:
+    """E2E tests for get_nodes functionality."""
+
+    def test_get_nodes_returns_list(self, ws_manager, rosapi_nodes_type):
+        """Verify get_nodes returns a list of running nodes."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/nodes",
+            "type": rosapi_nodes_type,
+            "args": {},
+            "id": "get_nodes_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "error" not in response
+        assert "values" in response
+
+        nodes = response["values"].get("nodes", [])
+        assert isinstance(nodes, list)
+        assert len(nodes) > 0, "Should have at least one node running"
+
+    def test_get_nodes_contains_turtlesim(self, ws_manager, rosapi_nodes_type):
+        """Verify turtlesim node is in the list."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/nodes",
+            "type": rosapi_nodes_type,
+            "args": {},
+            "id": "get_nodes_turtlesim_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        nodes = response.get("values", {}).get("nodes", [])
+
+        # Look for turtlesim node (might be named /turtlesim or similar)
+        turtlesim_nodes = [n for n in nodes if "turtlesim" in n.lower()]
+        assert len(turtlesim_nodes) > 0, f"Expected turtlesim node in {nodes}"
+
+    def test_get_nodes_contains_rosbridge(self, ws_manager, rosapi_nodes_type):
+        """Verify rosbridge node is in the list."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/nodes",
+            "type": rosapi_nodes_type,
+            "args": {},
+            "id": "get_nodes_rosbridge_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        nodes = response.get("values", {}).get("nodes", [])
+
+        # Look for rosbridge node
+        rosbridge_nodes = [n for n in nodes if "rosbridge" in n.lower()]
+        assert len(rosbridge_nodes) > 0, f"Expected rosbridge node in {nodes}"
+
+
+class TestGetNodeDetails:
+    """E2E tests for get_node_details functionality."""
+
+    def test_get_turtlesim_node_details(self, ws_manager, rosapi_nodes_type, rosapi_node_details_type):
+        """Get details for turtlesim node."""
+        # First get the turtlesim node name
+        nodes_msg = {
+            "op": "call_service",
+            "service": "/rosapi/nodes",
+            "type": rosapi_nodes_type,
+            "args": {},
+            "id": "get_nodes_for_details",
+        }
+
+        with ws_manager:
+            nodes_response = ws_manager.request(nodes_msg, timeout=10.0)
+
+        nodes = nodes_response.get("values", {}).get("nodes", [])
+        turtlesim_node = next((n for n in nodes if "turtlesim" in n.lower()), None)
+
+        if not turtlesim_node:
+            pytest.skip("Turtlesim node not found")
+
+        # Get node details
+        details_msg = {
+            "op": "call_service",
+            "service": "/rosapi/node_details",
+            "type": rosapi_node_details_type,
+            "args": {"node": turtlesim_node},
+            "id": "get_node_details_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(details_msg, timeout=10.0)
+
+        assert "error" not in response
+        assert "values" in response
+
+        values = response["values"]
+
+        # Turtlesim should have publishers, subscribers, and services
+        publishers = values.get("publishing", [])
+        subscribers = values.get("subscribing", [])
+
+        # Check for expected turtlesim topics
+        assert any("pose" in p for p in publishers), f"Expected pose publisher in {publishers}"
+        assert any("cmd_vel" in s for s in subscribers), (
+            f"Expected cmd_vel subscriber in {subscribers}"
+        )
+
+    def test_get_node_details_has_services(self, ws_manager, rosapi_nodes_type, rosapi_node_details_type):
+        """Verify node details include services."""
+        # Get turtlesim node
+        nodes_msg = {
+            "op": "call_service",
+            "service": "/rosapi/nodes",
+            "type": rosapi_nodes_type,
+            "args": {},
+            "id": "get_nodes_for_services",
+        }
+
+        with ws_manager:
+            nodes_response = ws_manager.request(nodes_msg, timeout=10.0)
+
+        nodes = nodes_response.get("values", {}).get("nodes", [])
+        turtlesim_node = next((n for n in nodes if "turtlesim" in n.lower()), None)
+
+        if not turtlesim_node:
+            pytest.skip("Turtlesim node not found")
+
+        details_msg = {
+            "op": "call_service",
+            "service": "/rosapi/node_details",
+            "type": rosapi_node_details_type,
+            "args": {"node": turtlesim_node},
+            "id": "get_node_services_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(details_msg, timeout=10.0)
+
+        services = response.get("values", {}).get("services", [])
+
+        # Turtlesim has several services
+        expected_services = ["teleport", "set_pen"]
+        for expected in expected_services:
+            assert any(expected in s for s in services), (
+                f"Expected service containing '{expected}' in {services}"
+            )
+
+
+class TestNodeIntegration:
+    """Integration tests for node operations."""
+
+    def test_list_nodes_then_get_details(self, ws_manager, rosapi_nodes_type, rosapi_node_details_type):
+        """Workflow: list nodes then get details for each."""
+        # Get all nodes
+        nodes_msg = {
+            "op": "call_service",
+            "service": "/rosapi/nodes",
+            "type": rosapi_nodes_type,
+            "args": {},
+            "id": "integration_get_nodes",
+        }
+
+        with ws_manager:
+            nodes_response = ws_manager.request(nodes_msg, timeout=10.0)
+
+        nodes = nodes_response.get("values", {}).get("nodes", [])
+        assert len(nodes) > 0
+
+        # Get details for first node
+        first_node = nodes[0]
+        details_msg = {
+            "op": "call_service",
+            "service": "/rosapi/node_details",
+            "type": rosapi_node_details_type,
+            "args": {"node": first_node},
+            "id": "integration_get_details",
+        }
+
+        with ws_manager:
+            details_response = ws_manager.request(details_msg, timeout=10.0)
+
+        # Should get valid response
+        assert "values" in details_response
+        values = details_response["values"]
+
+        # Note: Some internal nodes might have no visible publishers/subscribers
+        # so we just check we got a valid response structure
+        assert isinstance(values.get("publishing", []), list)
+        assert isinstance(values.get("subscribing", []), list)
+        assert isinstance(values.get("services", []), list)

--- a/tests/e2e/test_e2e_parameters.py
+++ b/tests/e2e/test_e2e_parameters.py
@@ -1,0 +1,237 @@
+"""E2E tests for parameter operations with real ROS 2 turtlesim.
+
+Parameter interfaces are significantly different between ROS 1 and ROS 2.
+ROS 2 uses node-namespaced parameters with rcl_interfaces, while ROS 1
+uses a global parameter server. This module tests ROS 2 specific functionality.
+"""
+
+import pytest
+
+# Mark all tests in this module as e2e and ros2-only
+pytestmark = [pytest.mark.e2e, pytest.mark.ros2]
+
+
+class TestGetParameter:
+    """E2E tests for get_parameter functionality."""
+
+    def test_get_turtlesim_background_parameter(self, ws_manager):
+        """Get turtlesim background color parameter."""
+        # Turtlesim has background_r, background_g, background_b parameters
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/get_param",
+            "type": "rosapi_msgs/srv/GetParam",
+            "args": {"name": "/turtlesim:background_r"},
+            "id": "get_param_background_r",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        # Should get a value (default is 69 for blue background)
+        if "values" in response:
+            value = response["values"].get("value", "")
+            # Value should be a number string
+            assert value, "Expected non-empty value for background_r"
+
+    def test_get_nonexistent_parameter(self, ws_manager):
+        """Get a parameter that doesn't exist."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/get_param",
+            "type": "rosapi_msgs/srv/GetParam",
+            "args": {"name": "/turtlesim:nonexistent_param_xyz"},
+            "id": "get_param_nonexistent",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        # Should return empty value or unsuccessful
+        if "values" in response:
+            value = response["values"].get("value", "")
+            # Empty, quoted empty string, or "null" indicates not found
+            assert value in ["", '""', None, "null"] or not response["values"].get("successful", True)
+
+
+class TestSetParameter:
+    """E2E tests for set_parameter functionality."""
+
+    def test_set_and_get_background_parameter(self, ws_manager):
+        """Set a turtlesim background parameter and verify it changed."""
+        # First get the original value
+        get_msg = {
+            "op": "call_service",
+            "service": "/rosapi/get_param",
+            "type": "rosapi_msgs/srv/GetParam",
+            "args": {"name": "/turtlesim:background_r"},
+            "id": "get_original_background_r",
+        }
+
+        with ws_manager:
+            original_response = ws_manager.request(get_msg, timeout=10.0)
+
+        original_value = original_response.get("values", {}).get("value", "69")
+
+        # Set to a new value
+        new_value = "100" if original_value != "100" else "150"
+        set_msg = {
+            "op": "call_service",
+            "service": "/rosapi/set_param",
+            "type": "rosapi_msgs/srv/SetParam",
+            "args": {"name": "/turtlesim:background_r", "value": new_value},
+            "id": "set_background_r",
+        }
+
+        with ws_manager:
+            set_response = ws_manager.request(set_msg, timeout=10.0)
+
+        # Verify the set operation (might succeed or fail based on permissions)
+        if set_response.get("values", {}).get("successful", False):
+            # Get the value again to verify
+            with ws_manager:
+                ws_manager.request(get_msg, timeout=10.0)
+            # Note: The actual change might require a service call to take effect
+
+        # Restore original value
+        restore_msg = {
+            "op": "call_service",
+            "service": "/rosapi/set_param",
+            "type": "rosapi_msgs/srv/SetParam",
+            "args": {"name": "/turtlesim:background_r", "value": original_value},
+            "id": "restore_background_r",
+        }
+
+        with ws_manager:
+            ws_manager.request(restore_msg, timeout=10.0)
+
+
+class TestGetParameters:
+    """E2E tests for listing parameters."""
+
+    def test_list_turtlesim_parameters(self, ws_manager, ros_version):
+        """List all parameters for turtlesim node."""
+        if ros_version == "1":
+            pytest.skip("rcl_interfaces/srv/ListParameters is ROS 2 specific")
+
+        message = {
+            "op": "call_service",
+            "service": "/turtlesim/list_parameters",
+            "type": "rcl_interfaces/srv/ListParameters",
+            "args": {},
+            "id": "list_turtlesim_params",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        if "values" in response:
+            result = response["values"].get("result", {})
+            names = result.get("names", [])
+
+            # Turtlesim should have background color parameters
+            expected_params = ["background_r", "background_g", "background_b"]
+            for param in expected_params:
+                assert any(param in name for name in names), f"Expected {param} in {names}"
+
+
+class TestHasParameter:
+    """E2E tests for checking parameter existence."""
+
+    def test_has_existing_parameter(self, ws_manager):
+        """Check that an existing parameter is found."""
+        # Use get_param to check existence (safer than has_param)
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/get_param",
+            "type": "rosapi_msgs/srv/GetParam",
+            "args": {"name": "/turtlesim:background_r"},
+            "id": "check_existing_param",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        # Should have a value
+        if "values" in response:
+            value = response["values"].get("value", "")
+            assert value and value not in ["", '""'], "Parameter should exist with value"
+
+    def test_has_nonexistent_parameter(self, ws_manager):
+        """Check that a non-existent parameter is not found."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/get_param",
+            "type": "rosapi_msgs/srv/GetParam",
+            "args": {"name": "/turtlesim:definitely_not_a_real_param"},
+            "id": "check_nonexistent_param",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        # Should have empty value or unsuccessful
+        if "values" in response:
+            value = response["values"].get("value", "")
+            # Empty, quoted empty string, or "null" indicates not found
+            assert value in ["", '""', None, "null"] or not response["values"].get("successful", True)
+
+
+class TestParameterIntegration:
+    """Integration tests for parameter operations."""
+
+    def test_parameter_workflow(self, ws_manager):
+        """Complete workflow: list, get, set, verify, restore."""
+        # 1. List parameters
+        list_msg = {
+            "op": "call_service",
+            "service": "/turtlesim/list_parameters",
+            "type": "rcl_interfaces/srv/ListParameters",
+            "args": {},
+            "id": "workflow_list_params",
+        }
+
+        with ws_manager:
+            list_response = ws_manager.request(list_msg, timeout=10.0)
+
+        if "values" not in list_response:
+            pytest.skip("Cannot list parameters")
+
+        # 2. Get background_g value
+        get_msg = {
+            "op": "call_service",
+            "service": "/rosapi/get_param",
+            "type": "rosapi_msgs/srv/GetParam",
+            "args": {"name": "/turtlesim:background_g"},
+            "id": "workflow_get_param",
+        }
+
+        with ws_manager:
+            get_response = ws_manager.request(get_msg, timeout=10.0)
+
+        original_value = get_response.get("values", {}).get("value", "86")
+
+        # 3. Set new value
+        new_value = "200"
+        set_msg = {
+            "op": "call_service",
+            "service": "/rosapi/set_param",
+            "type": "rosapi_msgs/srv/SetParam",
+            "args": {"name": "/turtlesim:background_g", "value": new_value},
+            "id": "workflow_set_param",
+        }
+
+        with ws_manager:
+            ws_manager.request(set_msg, timeout=10.0)
+
+        # 4. Restore original value
+        restore_msg = {
+            "op": "call_service",
+            "service": "/rosapi/set_param",
+            "type": "rosapi_msgs/srv/SetParam",
+            "args": {"name": "/turtlesim:background_g", "value": original_value},
+            "id": "workflow_restore_param",
+        }
+
+        with ws_manager:
+            ws_manager.request(restore_msg, timeout=10.0)

--- a/tests/e2e/test_e2e_prompts.py
+++ b/tests/e2e/test_e2e_prompts.py
@@ -1,0 +1,64 @@
+"""E2E tests for MCP prompts registration and content validation."""
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+class TestPromptsRegistration:
+    """E2E tests for prompt registration with MCP server."""
+
+    def test_prompts_registered_with_mcp(self, mcp_server):
+        """Verify prompts are registered with MCP server."""
+        # Access the registered prompts via the server's internal state
+        # FastMCP stores prompts in _prompt_manager
+        prompt_manager = mcp_server._prompt_manager
+        prompts = prompt_manager._prompts
+
+        assert len(prompts) > 0, "Expected at least one prompt to be registered"
+
+    def test_prompt_content_non_empty(self, mcp_server):
+        """Verify registered prompts have non-empty content."""
+        prompt_manager = mcp_server._prompt_manager
+        prompts = prompt_manager._prompts
+
+        for prompt_name, prompt_obj in prompts.items():
+            # Each prompt should have a description or function
+            assert prompt_obj is not None, f"Prompt {prompt_name} should not be None"
+
+    def test_prompt_names_follow_convention(self, mcp_server):
+        """Verify prompt names follow the naming convention (kebab-case)."""
+        prompt_manager = mcp_server._prompt_manager
+        prompts = prompt_manager._prompts
+
+        for prompt_name in prompts.keys():
+            # Prompt names should use kebab-case (lowercase with hyphens)
+            assert prompt_name == prompt_name.lower(), (
+                f"Prompt name {prompt_name} should be lowercase"
+            )
+            # Should not contain underscores (use hyphens instead)
+            assert "_" not in prompt_name or prompt_name.startswith("test_"), (
+                f"Prompt name {prompt_name} should use hyphens, not underscores"
+            )
+
+    def test_expected_prompts_exist(self, mcp_server):
+        """Verify expected prompts are registered."""
+        prompt_manager = mcp_server._prompt_manager
+        prompts = prompt_manager._prompts
+        prompt_names = list(prompts.keys())
+
+        # Expected prompts based on the project structure
+        expected_prompts = [
+            "test-server-tools",
+            "test-connection-tools",
+            "test-nodes-tools",
+            "test-services-tools",
+            "test-topics-tools",
+            "test-actions-tools",
+            "test-parameters-tools",
+        ]
+
+        for expected in expected_prompts:
+            assert expected in prompt_names, (
+                f"Expected prompt '{expected}' to be registered. Found: {prompt_names}"
+            )

--- a/tests/e2e/test_e2e_resources.py
+++ b/tests/e2e/test_e2e_resources.py
@@ -1,0 +1,118 @@
+"""E2E tests for MCP resources with real ROS environment."""
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+class TestRobotSpecsResources:
+    """E2E tests for robot specification resources."""
+
+    def test_robot_specs_list_available_robots(self, mcp_server):
+        """Verify robot specs resource lists available robots."""
+        # Access the resource manager
+        resource_manager = mcp_server._resource_manager
+        resources = resource_manager._resources
+
+        # Check that robot specs resource exists
+        robot_specs_uri = "ros-mcp://robot-specs/get_verified_robots_list"
+        assert robot_specs_uri in resources, (
+            f"Expected robot specs resource at {robot_specs_uri}"
+        )
+
+
+class TestRosMetadataResources:
+    """E2E tests for ROS metadata resources."""
+
+    def test_ros_metadata_all_returns_topics(self, ws_manager, rosapi_topics_type):
+        """Verify ROS metadata returns topics from running ROS system."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/topics",
+            "type": rosapi_topics_type,
+            "args": {},
+            "id": "metadata_topics_test",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "values" in response, f"Expected values in response: {response}"
+        topics = response["values"].get("topics", [])
+        assert len(topics) > 0, "Expected at least one topic from ROS system"
+
+    def test_ros_metadata_all_returns_services(self, ws_manager, rosapi_services_type):
+        """Verify ROS metadata returns services from running ROS system."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/services",
+            "type": rosapi_services_type,
+            "args": {},
+            "id": "metadata_services_test",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "values" in response, f"Expected values in response: {response}"
+        services = response["values"].get("services", [])
+        assert len(services) > 0, "Expected at least one service from ROS system"
+
+    def test_ros_metadata_all_returns_nodes(self, ws_manager, rosapi_nodes_type):
+        """Verify ROS metadata returns nodes from running ROS system."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/nodes",
+            "type": rosapi_nodes_type,
+            "args": {},
+            "id": "metadata_nodes_test",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "values" in response, f"Expected values in response: {response}"
+        nodes = response["values"].get("nodes", [])
+        assert len(nodes) > 0, "Expected at least one node from ROS system"
+
+    def test_ros_metadata_contains_turtlesim(self, ws_manager, rosapi_topics_type):
+        """Verify ROS metadata contains turtlesim-related entries."""
+        # Get topics
+        topics_message = {
+            "op": "call_service",
+            "service": "/rosapi/topics",
+            "type": rosapi_topics_type,
+            "args": {},
+            "id": "metadata_turtlesim_topics_test",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(topics_message, timeout=10.0)
+
+        topics = response.get("values", {}).get("topics", [])
+
+        # Check for turtlesim-related topics
+        turtlesim_topics = [t for t in topics if "turtle" in t.lower()]
+        assert len(turtlesim_topics) > 0, (
+            f"Expected turtlesim topics, found: {topics[:10]}..."
+        )
+
+    def test_resources_registered_with_mcp(self, mcp_server):
+        """Verify resources are registered with MCP server."""
+        resource_manager = mcp_server._resource_manager
+        resources = resource_manager._resources
+
+        assert len(resources) > 0, "Expected at least one resource to be registered"
+
+        # Check for expected resource URIs
+        expected_resources = [
+            "ros-mcp://robot-specs/get_verified_robots_list",
+            "ros-mcp://ros-metadata/topics/all",
+            "ros-mcp://ros-metadata/services/all",
+            "ros-mcp://ros-metadata/nodes/all",
+        ]
+
+        for expected in expected_resources:
+            assert expected in resources, (
+                f"Expected resource '{expected}' to be registered. Found: {list(resources.keys())}"
+            )

--- a/tests/e2e/test_e2e_robot_config.py
+++ b/tests/e2e/test_e2e_robot_config.py
@@ -1,0 +1,228 @@
+"""E2E tests for robot config operations with real ROS turtlesim."""
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+class TestDetectRosVersion:
+    """E2E tests for ROS version detection."""
+
+    def test_detect_ros_version(self, ws_manager, ros_version, rosapi_get_ros_version_type):
+        """Detect ROS version via rosapi."""
+        if rosapi_get_ros_version_type is None:
+            pytest.skip("get_ros_version service not available in ROS 1")
+
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/get_ros_version",
+            "type": rosapi_get_ros_version_type,
+            "args": {},
+            "id": "detect_ros_version_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        if "values" in response:
+            values = response["values"]
+            version = values.get("version")
+            distro = values.get("distro")
+
+            # Should detect the expected ROS version (may be int or string)
+            assert str(version) == ros_version, f"Expected ROS {ros_version}, got version {version}"
+            # Should have a valid distro name
+            assert distro, "Expected distro name"
+
+            if ros_version == "2":
+                # Common ROS 2 distros
+                valid_distros = [
+                    "humble",
+                    "iron",
+                    "jazzy",
+                    "rolling",
+                    "foxy",
+                    "galactic",
+                ]
+                assert any(d in distro.lower() for d in valid_distros), f"Unexpected distro: {distro}"
+            else:
+                # ROS 1 distros
+                valid_distros = ["noetic", "melodic"]
+                assert any(d in distro.lower() for d in valid_distros), f"Unexpected distro: {distro}"
+
+    @pytest.mark.ros2
+    def test_ros_version_response_format(self, ws_manager, rosapi_get_ros_version_type):
+        """Verify ROS version response has expected format (ROS 2 only)."""
+        if rosapi_get_ros_version_type is None:
+            pytest.skip("get_ros_version service not available in ROS 1")
+
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/get_ros_version",
+            "type": rosapi_get_ros_version_type,
+            "args": {},
+            "id": "ros_version_format_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        # Should have values or result
+        assert "values" in response or "result" in response
+
+        if "values" in response:
+            values = response["values"]
+            # Should have version and distro fields
+            assert "version" in values or "distro" in values
+
+
+class TestRosbridgeConnection:
+    """E2E tests for verifying rosbridge is working."""
+
+    def test_rosbridge_services_available(self, ws_manager, rosapi_services_type):
+        """Verify essential rosbridge services are available."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/services",
+            "type": rosapi_services_type,
+            "args": {},
+            "id": "check_rosbridge_services",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "values" in response
+        services = response["values"].get("services", [])
+
+        # Essential rosapi services should be available
+        essential_services = [
+            "/rosapi/topics",
+            "/rosapi/services",
+            "/rosapi/nodes",
+        ]
+
+        for service in essential_services:
+            assert service in services, f"Missing essential service: {service}"
+
+    def test_rosbridge_topics_available(self, ws_manager, rosapi_topics_type):
+        """Verify topics can be listed."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/topics",
+            "type": rosapi_topics_type,
+            "args": {},
+            "id": "check_rosbridge_topics",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "values" in response
+        topics = response["values"].get("topics", [])
+
+        # Should have turtlesim topics
+        assert len(topics) > 0, "Should have at least one topic"
+        turtlesim_topics = [t for t in topics if "turtle" in t.lower()]
+        assert len(turtlesim_topics) > 0, f"Expected turtlesim topics in {topics}"
+
+
+class TestRobotConfigIntegration:
+    """Integration tests for robot configuration."""
+
+    @pytest.mark.ros2
+    def test_detect_version_and_list_capabilities(
+        self, ws_manager, rosapi_get_ros_version_type, rosapi_services_type
+    ):
+        """Detect ROS version and list available capabilities (ROS 2 only)."""
+        if rosapi_get_ros_version_type is None:
+            pytest.skip("get_ros_version service not available in ROS 1")
+
+        # 1. Get ROS version
+        version_msg = {
+            "op": "call_service",
+            "service": "/rosapi/get_ros_version",
+            "type": rosapi_get_ros_version_type,
+            "args": {},
+            "id": "integration_get_version",
+        }
+
+        with ws_manager:
+            version_response = ws_manager.request(version_msg, timeout=10.0)
+
+        version = version_response.get("values", {}).get("version", "unknown")
+
+        # 2. Based on version, check for ROS 2 specific services
+        if str(version) == "2":
+            # Check for ROS 2 specific services like action_servers
+            services_msg = {
+                "op": "call_service",
+                "service": "/rosapi/services",
+                "type": rosapi_services_type,
+                "args": {},
+                "id": "integration_get_services",
+            }
+
+            with ws_manager:
+                services_response = ws_manager.request(services_msg, timeout=10.0)
+
+            services = services_response.get("values", {}).get("services", [])
+
+            # ROS 2 should have parameter services
+            param_services = [s for s in services if "param" in s.lower()]
+            assert len(param_services) > 0, "ROS 2 should have parameter services"
+
+    def test_full_system_check(
+        self, ws_manager, ros_version, rosapi_nodes_type, rosapi_topics_type, rosapi_services_type
+    ):
+        """Comprehensive system check: nodes, topics, services."""
+        results = {}
+        results["version"] = ros_version
+
+        # Check nodes
+        nodes_msg = {
+            "op": "call_service",
+            "service": "/rosapi/nodes",
+            "type": rosapi_nodes_type,
+            "args": {},
+            "id": "system_check_nodes",
+        }
+
+        with ws_manager:
+            nodes_response = ws_manager.request(nodes_msg, timeout=10.0)
+
+        results["node_count"] = len(nodes_response.get("values", {}).get("nodes", []))
+
+        # Check topics
+        topics_msg = {
+            "op": "call_service",
+            "service": "/rosapi/topics",
+            "type": rosapi_topics_type,
+            "args": {},
+            "id": "system_check_topics",
+        }
+
+        with ws_manager:
+            topics_response = ws_manager.request(topics_msg, timeout=10.0)
+
+        results["topic_count"] = len(topics_response.get("values", {}).get("topics", []))
+
+        # Check services
+        services_msg = {
+            "op": "call_service",
+            "service": "/rosapi/services",
+            "type": rosapi_services_type,
+            "args": {},
+            "id": "system_check_services",
+        }
+
+        with ws_manager:
+            services_response = ws_manager.request(services_msg, timeout=10.0)
+
+        results["service_count"] = len(services_response.get("values", {}).get("services", []))
+
+        # Verify we got valid data
+        assert str(results["version"]) == ros_version, f"Should be ROS {ros_version}"
+        assert results["node_count"] > 0, "Should have nodes running"
+        assert results["topic_count"] > 0, "Should have topics available"
+        assert results["service_count"] > 0, "Should have services available"

--- a/tests/e2e/test_e2e_services.py
+++ b/tests/e2e/test_e2e_services.py
@@ -1,0 +1,317 @@
+"""E2E tests for service operations with real ROS turtlesim."""
+
+import math
+import time
+
+import pytest
+
+from tests.e2e.conftest import get_turtle_pose, reset_turtle, teleport_turtle
+
+pytestmark = pytest.mark.e2e
+
+
+class TestGetServices:
+    """E2E tests for get_services functionality."""
+
+    def test_get_services_returns_turtlesim_services(self, ws_manager, turtlesim_services, ros_version):
+        """Verify turtlesim services exist in service list."""
+        # rosapi service type varies by ROS version
+        service_type = "rosapi/Services" if ros_version == "1" else "rosapi_msgs/srv/Services"
+
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/services",
+            "type": service_type,
+            "args": {},
+            "id": "get_services_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "values" in response, f"Expected values in response: {response}"
+        services = response["values"].get("services", [])
+
+        # Check for expected turtlesim services
+        for expected_service in turtlesim_services:
+            assert expected_service in services, f"Expected {expected_service} in services"
+
+    def test_get_services_includes_rosapi(self, ws_manager, ros_version):
+        """Verify rosapi services are also listed."""
+        service_type = "rosapi/Services" if ros_version == "1" else "rosapi_msgs/srv/Services"
+
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/services",
+            "type": service_type,
+            "args": {},
+            "id": "get_services_rosapi_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        services = response.get("values", {}).get("services", [])
+
+        # Check for some rosapi services
+        rosapi_services = [s for s in services if "/rosapi/" in s]
+        assert len(rosapi_services) > 0, "Should have rosapi services"
+
+
+class TestCallTeleportAbsolute:
+    """E2E tests for teleport_absolute service."""
+
+    def test_teleport_to_center(self, ws_manager, service_type_teleport, service_type_empty, msg_type_pose):
+        """Teleport turtle to center of screen."""
+        # First reset
+        reset_turtle(ws_manager, service_type_empty)
+
+        # Teleport to center (5.5, 5.5)
+        message = {
+            "op": "call_service",
+            "service": "/turtle1/teleport_absolute",
+            "type": service_type_teleport,
+            "args": {"x": 5.5, "y": 5.5, "theta": 0.0},
+            "id": "teleport_center_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        # Service should succeed (empty response for TeleportAbsolute)
+        assert "error" not in response, f"Service call should succeed: {response}"
+
+        # Verify turtle is at the target position
+        time.sleep(0.3)
+        pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        assert pose is not None, "Should get pose after teleport"
+        assert abs(pose["x"] - 5.5) < 0.1, f"x should be ~5.5, got {pose['x']}"
+        assert abs(pose["y"] - 5.5) < 0.1, f"y should be ~5.5, got {pose['y']}"
+
+    def test_teleport_to_corner(self, ws_manager, service_type_teleport, msg_type_pose):
+        """Teleport turtle to top-right corner."""
+        message = {
+            "op": "call_service",
+            "service": "/turtle1/teleport_absolute",
+            "type": service_type_teleport,
+            "args": {"x": 10.0, "y": 10.0, "theta": math.pi / 2},
+            "id": "teleport_corner_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "error" not in response
+
+        time.sleep(0.3)
+        pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        assert pose is not None
+        assert abs(pose["x"] - 10.0) < 0.1, f"x should be ~10.0, got {pose['x']}"
+        assert abs(pose["y"] - 10.0) < 0.1, f"y should be ~10.0, got {pose['y']}"
+
+    def test_teleport_sets_orientation(self, ws_manager, service_type_teleport, msg_type_pose):
+        """Verify teleport sets the correct orientation."""
+        target_theta = math.pi / 4  # 45 degrees
+
+        message = {
+            "op": "call_service",
+            "service": "/turtle1/teleport_absolute",
+            "type": service_type_teleport,
+            "args": {"x": 5.5, "y": 5.5, "theta": target_theta},
+            "id": "teleport_orientation_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "error" not in response
+
+        time.sleep(0.3)
+        pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        assert pose is not None
+        # Allow some tolerance for theta comparison
+        assert abs(pose["theta"] - target_theta) < 0.1, (
+            f"theta should be ~{target_theta}, got {pose['theta']}"
+        )
+
+
+class TestCallSpawnService:
+    """E2E tests for spawn service."""
+
+    def test_spawn_new_turtle(self, ws_manager, service_type_spawn, service_type_kill, ros_version):
+        """Spawn a new turtle and verify new topics appear."""
+        # First, get current topics
+        topics_type = "rosapi/Topics" if ros_version == "1" else "rosapi/Topics"
+        topics_msg = {
+            "op": "call_service",
+            "service": "/rosapi/topics",
+            "type": topics_type,
+            "args": {},
+            "id": "get_topics_before_spawn",
+        }
+
+        with ws_manager:
+            ws_manager.request(topics_msg, timeout=10.0)
+
+        # Spawn a new turtle
+        spawn_msg = {
+            "op": "call_service",
+            "service": "/spawn",
+            "type": service_type_spawn,
+            "args": {"x": 2.0, "y": 2.0, "theta": 0.0, "name": "turtle2"},
+            "id": "spawn_turtle2_e2e",
+        }
+
+        with ws_manager:
+            spawn_response = ws_manager.request(spawn_msg, timeout=10.0)
+
+        # Spawn should return the name
+        if "values" in spawn_response:
+            assert spawn_response["values"].get("name") == "turtle2"
+
+        # Wait for new topics to register
+        time.sleep(1.0)
+
+        # Verify new topics exist
+        with ws_manager:
+            new_topics_response = ws_manager.request(topics_msg, timeout=10.0)
+
+        new_topics = new_topics_response.get("values", {}).get("topics", [])
+
+        assert "/turtle2/cmd_vel" in new_topics, "Should have turtle2 cmd_vel topic"
+        assert "/turtle2/pose" in new_topics, "Should have turtle2 pose topic"
+
+        # Clean up - kill the spawned turtle
+        kill_msg = {
+            "op": "call_service",
+            "service": "/kill",
+            "type": service_type_kill,
+            "args": {"name": "turtle2"},
+            "id": "kill_turtle2_e2e",
+        }
+
+        with ws_manager:
+            ws_manager.request(kill_msg, timeout=5.0)
+
+
+class TestCallClearService:
+    """E2E tests for clear service."""
+
+    def test_call_clear_service(self, ws_manager, service_type_empty):
+        """Verify clear service can be called successfully."""
+        message = {
+            "op": "call_service",
+            "service": "/clear",
+            "type": service_type_empty,
+            "args": {},
+            "id": "clear_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        # Clear service should succeed (empty response)
+        assert "error" not in response, f"Clear service should succeed: {response}"
+
+
+class TestCallResetService:
+    """E2E tests for reset service."""
+
+    def test_reset_returns_turtle_to_center(self, ws_manager, service_type_empty, service_type_teleport, msg_type_pose):
+        """Verify reset service returns turtle to initial position."""
+        # First, move turtle away from center
+        teleport_turtle(ws_manager, 2.0, 2.0, 0.0, service_type_teleport)
+        time.sleep(0.3)
+
+        # Call reset
+        message = {
+            "op": "call_service",
+            "service": "/reset",
+            "type": service_type_empty,
+            "args": {},
+            "id": "reset_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "error" not in response
+
+        # Verify turtle is back at center
+        time.sleep(0.5)
+        pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        assert pose is not None
+
+        # Default turtlesim starting position is approximately (5.5, 5.5)
+        assert 5.0 < pose["x"] < 6.0, f"x should be near center, got {pose['x']}"
+        assert 5.0 < pose["y"] < 6.0, f"y should be near center, got {pose['y']}"
+
+
+class TestCallSetPenService:
+    """E2E tests for set_pen service."""
+
+    def test_set_pen_color(self, ws_manager, service_type_set_pen):
+        """Verify set_pen service can be called to change pen settings."""
+        message = {
+            "op": "call_service",
+            "service": "/turtle1/set_pen",
+            "type": service_type_set_pen,
+            "args": {
+                "r": 255,
+                "g": 0,
+                "b": 0,
+                "width": 3,
+                "off": 0,
+            },
+            "id": "set_pen_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        # SetPen should succeed (empty response)
+        assert "error" not in response, f"SetPen service should succeed: {response}"
+
+    def test_set_pen_off(self, ws_manager, service_type_set_pen):
+        """Verify set_pen can disable drawing."""
+        message = {
+            "op": "call_service",
+            "service": "/turtle1/set_pen",
+            "type": service_type_set_pen,
+            "args": {
+                "r": 0,
+                "g": 0,
+                "b": 0,
+                "width": 1,
+                "off": 1,  # Disable pen
+            },
+            "id": "set_pen_off_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "error" not in response
+
+
+class TestServiceDetails:
+    """E2E tests for getting service details."""
+
+    def test_get_service_type(self, ws_manager, ros_version):
+        """Get service type for teleport_absolute."""
+        service_type = "rosapi/ServiceType" if ros_version == "1" else "rosapi_msgs/srv/ServiceType"
+
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/service_type",
+            "type": service_type,
+            "args": {"service": "/turtle1/teleport_absolute"},
+            "id": "get_service_type_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "values" in response
+        svc_type = response["values"].get("type", "")
+        assert "TeleportAbsolute" in svc_type, f"Expected TeleportAbsolute, got {svc_type}"

--- a/tests/e2e/test_e2e_topics.py
+++ b/tests/e2e/test_e2e_topics.py
@@ -1,0 +1,293 @@
+"""E2E tests for topic operations with real ROS turtlesim."""
+
+import json
+import math
+import time
+
+import pytest
+
+from tests.e2e.conftest import get_turtle_pose, reset_turtle, teleport_turtle
+
+pytestmark = pytest.mark.e2e
+
+
+class TestGetTopics:
+    """E2E tests for get_topics functionality."""
+
+    def test_get_topics_returns_turtlesim_topics(self, ws_manager, turtlesim_topics, rosapi_topics_type):
+        """Verify turtlesim topics exist in topic list."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/topics",
+            "type": rosapi_topics_type,
+            "args": {},
+            "id": "get_topics_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "values" in response, f"Expected values in response: {response}"
+        topics = response["values"].get("topics", [])
+
+        # Check for expected turtlesim topics
+        for expected_topic in turtlesim_topics:
+            assert expected_topic in topics, f"Expected {expected_topic} in topics"
+
+    def test_get_topics_returns_types(self, ws_manager, rosapi_topics_type):
+        """Verify topic types are returned correctly."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/topics",
+            "type": rosapi_topics_type,
+            "args": {},
+            "id": "get_topics_types_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "values" in response
+        topics = response["values"].get("topics", [])
+        types = response["values"].get("types", [])
+
+        assert len(topics) == len(types), "Topics and types lists should have same length"
+
+        # Find cmd_vel and verify its type
+        if "/turtle1/cmd_vel" in topics:
+            idx = topics.index("/turtle1/cmd_vel")
+            assert "Twist" in types[idx], f"Expected Twist type, got {types[idx]}"
+
+
+class TestGetTopicType:
+    """E2E tests for get_topic_type functionality."""
+
+    def test_get_topic_type_cmd_vel(self, ws_manager, rosapi_topic_type_type):
+        """Verify type of cmd_vel topic."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/topic_type",
+            "type": rosapi_topic_type_type,
+            "args": {"topic": "/turtle1/cmd_vel"},
+            "id": "get_topic_type_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "values" in response
+        topic_type = response["values"].get("type", "")
+        assert "Twist" in topic_type, f"Expected Twist type, got {topic_type}"
+
+    def test_get_topic_type_pose(self, ws_manager, rosapi_topic_type_type):
+        """Verify type of pose topic."""
+        message = {
+            "op": "call_service",
+            "service": "/rosapi/topic_type",
+            "type": rosapi_topic_type_type,
+            "args": {"topic": "/turtle1/pose"},
+            "id": "get_topic_type_pose_e2e",
+        }
+
+        with ws_manager:
+            response = ws_manager.request(message, timeout=10.0)
+
+        assert "values" in response
+        topic_type = response["values"].get("type", "")
+        assert "Pose" in topic_type, f"Expected Pose type, got {topic_type}"
+
+
+class TestSubscribeOnce:
+    """E2E tests for subscribe_once functionality."""
+
+    def test_subscribe_once_pose(self, ws_manager, msg_type_pose):
+        """Subscribe to pose topic and verify message structure."""
+        subscribe_msg = {
+            "op": "subscribe",
+            "topic": "/turtle1/pose",
+            "type": msg_type_pose,
+        }
+
+        with ws_manager:
+            ws_manager.send(subscribe_msg)
+
+            # Wait for a pose message
+            end_time = time.time() + 10.0
+            received_msg = None
+
+            while time.time() < end_time:
+                response = ws_manager.receive(timeout=1.0)
+                if response:
+                    data = json.loads(response)
+                    if data.get("op") == "publish" and data.get("topic") == "/turtle1/pose":
+                        received_msg = data.get("msg", {})
+                        break
+
+            # Unsubscribe
+            ws_manager.send({"op": "unsubscribe", "topic": "/turtle1/pose"})
+
+        assert received_msg is not None, "Should receive pose message"
+        assert "x" in received_msg, "Pose should have x coordinate"
+        assert "y" in received_msg, "Pose should have y coordinate"
+        assert "theta" in received_msg, "Pose should have theta"
+        assert "linear_velocity" in received_msg, "Pose should have linear_velocity"
+        assert "angular_velocity" in received_msg, "Pose should have angular_velocity"
+
+    def test_subscribe_once_pose_values_reasonable(self, ws_manager, msg_type_pose):
+        """Verify pose values are within expected bounds."""
+        pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+
+        assert pose is not None, "Should receive pose"
+        # Turtlesim window is 11x11
+        assert 0.0 <= pose["x"] <= 11.0, f"x should be in [0, 11], got {pose['x']}"
+        assert 0.0 <= pose["y"] <= 11.0, f"y should be in [0, 11], got {pose['y']}"
+        # theta is in radians, typically -pi to pi
+        assert -math.pi <= pose["theta"] <= math.pi or -2 * math.pi <= pose["theta"] <= 2 * math.pi
+
+
+class TestPublishCmdVel:
+    """E2E tests for publishing to cmd_vel topic."""
+
+    def test_publish_cmd_vel_moves_turtle(
+        self, ws_manager, service_type_empty, service_type_teleport, msg_type_twist, msg_type_pose
+    ):
+        """Verify publishing to cmd_vel moves the turtle."""
+        # First, reset turtle and get initial pose
+        reset_turtle(ws_manager, service_type_empty)
+        time.sleep(0.5)
+        initial_pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        assert initial_pose is not None, "Should get initial pose"
+
+        # Teleport to known position
+        teleport_turtle(ws_manager, 5.5, 5.5, 0.0, service_type_teleport)
+        time.sleep(0.3)
+
+        # Now publish a movement command
+        with ws_manager:
+            # Advertise
+            advertise_msg = {
+                "op": "advertise",
+                "topic": "/turtle1/cmd_vel",
+                "type": msg_type_twist,
+            }
+            ws_manager.send(advertise_msg)
+            time.sleep(0.2)
+
+            # Publish forward movement
+            publish_msg = {
+                "op": "publish",
+                "topic": "/turtle1/cmd_vel",
+                "msg": {
+                    "linear": {"x": 2.0, "y": 0.0, "z": 0.0},
+                    "angular": {"x": 0.0, "y": 0.0, "z": 0.0},
+                },
+            }
+            ws_manager.send(publish_msg)
+            time.sleep(0.5)  # Let the turtle move
+
+            # Stop the turtle
+            stop_msg = {
+                "op": "publish",
+                "topic": "/turtle1/cmd_vel",
+                "msg": {
+                    "linear": {"x": 0.0, "y": 0.0, "z": 0.0},
+                    "angular": {"x": 0.0, "y": 0.0, "z": 0.0},
+                },
+            }
+            ws_manager.send(stop_msg)
+
+            # Unadvertise
+            ws_manager.send({"op": "unadvertise", "topic": "/turtle1/cmd_vel"})
+
+        # Get new pose and verify movement
+        time.sleep(0.3)
+        new_pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        assert new_pose is not None, "Should get new pose"
+
+        # Turtle should have moved forward (x increased since facing right at theta=0)
+        assert new_pose["x"] > 5.5, (
+            f"Turtle should have moved right, x was 5.5, now {new_pose['x']}"
+        )
+
+    def test_publish_angular_rotates_turtle(
+        self, ws_manager, service_type_empty, service_type_teleport, msg_type_twist, msg_type_pose
+    ):
+        """Verify publishing angular velocity rotates the turtle."""
+        # Reset and teleport to known position/orientation
+        reset_turtle(ws_manager, service_type_empty)
+        teleport_turtle(ws_manager, 5.5, 5.5, 0.0, service_type_teleport)
+        time.sleep(0.3)
+
+        initial_pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        initial_theta = initial_pose["theta"]
+
+        # Publish rotation command
+        with ws_manager:
+            advertise_msg = {
+                "op": "advertise",
+                "topic": "/turtle1/cmd_vel",
+                "type": msg_type_twist,
+            }
+            ws_manager.send(advertise_msg)
+            time.sleep(0.2)
+
+            # Rotate counter-clockwise
+            publish_msg = {
+                "op": "publish",
+                "topic": "/turtle1/cmd_vel",
+                "msg": {
+                    "linear": {"x": 0.0, "y": 0.0, "z": 0.0},
+                    "angular": {"x": 0.0, "y": 0.0, "z": 2.0},
+                },
+            }
+            ws_manager.send(publish_msg)
+            time.sleep(0.5)
+
+            # Stop
+            stop_msg = {
+                "op": "publish",
+                "topic": "/turtle1/cmd_vel",
+                "msg": {
+                    "linear": {"x": 0.0, "y": 0.0, "z": 0.0},
+                    "angular": {"x": 0.0, "y": 0.0, "z": 0.0},
+                },
+            }
+            ws_manager.send(stop_msg)
+            ws_manager.send({"op": "unadvertise", "topic": "/turtle1/cmd_vel"})
+
+        time.sleep(0.3)
+        new_pose = get_turtle_pose(ws_manager, msg_type=msg_type_pose)
+        assert new_pose is not None, "Should get new pose"
+
+        # Theta should have changed
+        assert new_pose["theta"] != initial_theta, "Turtle should have rotated"
+
+
+class TestSubscribeForDuration:
+    """E2E tests for subscribing for a duration."""
+
+    def test_collect_multiple_pose_messages(self, ws_manager, msg_type_pose):
+        """Verify collecting multiple messages over time."""
+        subscribe_msg = {
+            "op": "subscribe",
+            "topic": "/turtle1/pose",
+            "type": msg_type_pose,
+        }
+
+        messages = []
+
+        with ws_manager:
+            ws_manager.send(subscribe_msg)
+
+            end_time = time.time() + 2.0  # Collect for 2 seconds
+            while time.time() < end_time and len(messages) < 10:
+                response = ws_manager.receive(timeout=0.5)
+                if response:
+                    data = json.loads(response)
+                    if data.get("op") == "publish" and data.get("topic") == "/turtle1/pose":
+                        messages.append(data.get("msg", {}))
+
+            ws_manager.send({"op": "unsubscribe", "topic": "/turtle1/pose"})
+
+        # Pose topic publishes at ~60Hz, so we should get multiple messages
+        assert len(messages) > 1, f"Should collect multiple messages, got {len(messages)}"


### PR DESCRIPTION
## Summary
- Add comprehensive end-to-end tests that run against real ROS environments
- Docker-based turtlesim for both ROS 1 (Noetic) and ROS 2 (Humble)
- GitHub Actions workflow for automated CI

## E2E Test Coverage

| Test File | Description |
|-----------|-------------|
| `test_e2e_topics.py` | Topic listing, subscribing, publishing with real turtlesim |
| `test_e2e_services.py` | Service calls (spawn, kill, teleport) with real turtlesim |
| `test_e2e_nodes.py` | Node listing and details from real ROS |
| `test_e2e_parameters.py` | Parameter get/set/list (ROS 2 specific) |
| `test_e2e_actions.py` | Action server operations (ROS 2 specific) |
| `test_e2e_images.py` | Image subscription and processing |
| `test_e2e_robot_config.py` | ROS version detection and configuration |
| `test_e2e_integration.py` | Multi-tool workflows (e.g., spawn turtle -> move -> verify) |
| `test_e2e_error_handling.py` | Invalid inputs, connection failures, timeouts |
| `test_e2e_main.py` | CLI argument parsing, server initialization |
| `test_e2e_prompts.py` | MCP prompt registration and content |
| `test_e2e_resources.py` | MCP resource availability |

## Running E2E Tests

```bash
# ROS 2 (default)
docker compose -f tests/e2e/docker-compose.e2e.yml up -d
pytest tests/e2e/ -v -m e2e

# ROS 1
docker compose -f tests/e2e/docker-compose.ros1.yml up -d
pytest tests/e2e/ -v -m "e2e and not ros2" --ros-version=1
```

## Test plan
- [ ] Start ROS 2 Docker environment and run E2E tests
- [ ] Start ROS 1 Docker environment and run ROS 1 tests
- [ ] Verify GitHub Actions workflow triggers on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)