### PR TITLE
fix: allow pytest exit code 5 (no tests collected)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run tests
         run: |
           if [ -d tests ]; then
-            uv run pytest -q -m "not slow"
+            uv run pytest -q -m "not slow" || [ $? -eq 5 ]  # exit 5 = no tests collected
           else
             echo "No tests/ directory; skipping."
           fi

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run tests
         run: |
           if [ -d tests ]; then
-            uv run pytest -q -m "not slow"
+            uv run pytest -q -m "not slow" || [ $? -eq 5 ]  # exit 5 = no tests collected
           else
             echo "No tests/ directory; skipping."
           fi


### PR DESCRIPTION
## Summary
- Allow pytest exit code 5 (no tests collected) to pass in CI workflows
- All current tests are marked as `slow`, so `-m "not slow"` selects none

## Context
Follow-up to #231. The previous fix skipped slow tests, but since all tests are slow, pytest returns exit code 5 (no tests collected) which fails the workflow.

## Test plan
- [ ] Merge this PR
- [ ] Tag `v3.0.1` on main
- [ ] Verify publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)