### PR TITLE
hotfix: update MCP registry schema to 2025-12-11

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.robotmcp/ros-mcp-server",
   "description": "Connect AI models like Claude & ChatGPT with ROS robots using MCP",
   "repository": {


### PR DESCRIPTION
## Summary
- Update `server.json` schema URL from deprecated `2025-10-17` to current `2025-12-11`

## Context
v3.0.1 published to PyPI successfully but failed to publish to MCP Registry due to deprecated schema. After merging, manually trigger the "Publish MCP Registry" workflow to complete the v3.0.1 release.

