### PR TITLE
Fix documentation typos and bugs across example READMEs

### DIFF
--- a/examples/5_docker_turtlesim/README.md
+++ b/examples/5_docker_turtlesim/README.md
@@ -55,7 +55,7 @@ docker compose build --no-cache turtlesim
 The easiest way to launch turtlesim with proper X11 setup:
 
 ```bash
-./scrips/launch.sh
+./scripts/launch.sh
 ```
 
 This script automatically detects your OS and handles all platform-specific X11 configuration. It will:
@@ -105,7 +105,7 @@ docker exec -it ros2-turtlesim bash
 Once inside the container, you can manually launch turtle teleop to control the turtle:
 
 ```bash
-source /opt/ros/${ROS_DISTRO}$/setup.bash
+source /opt/ros/${ROS_DISTRO}/setup.bash
 ros2 run turtlesim turtle_teleop_key
 ```
 
@@ -261,7 +261,7 @@ If the automatic launch isn't working or you prefer to launch turtlesim manually
 docker exec -it ros2-turtlesim bash
 
 # Source ROS2 environment
-source /opt/ros/${ROS_DISTRO}$/setup.bash
+source /opt/ros/${ROS_DISTRO}/setup.bash
 
 # Start turtlesim in one terminal
 ros2 run turtlesim turtlesim_node
@@ -283,7 +283,7 @@ In a separate terminal, you can inspect the ROS2 topics:
 docker exec -it ros2-turtlesim bash
 
 # Source ROS2 environment
-source /opt/ros/${ROS_DISTRO}$/setup.bash
+source /opt/ros/${ROS_DISTRO}/setup.bash
 
 # List all topics
 ros2 topic list

--- a/examples/6_chatgpt/README.md
+++ b/examples/6_chatgpt/README.md
@@ -4,7 +4,7 @@
 
 ### Prepare host machine (MCP Server)
 
-* Installation of ChatGPT Desktop. Download [here](chatgpt.com/download) or Microsoft Store.
+* Installation of ChatGPT Desktop. Download [here](https://chatgpt.com/download) or Microsoft Store.
 * Installation of WSL (Linux).
 
 ### Prepare target robot (ROS)
@@ -218,7 +218,7 @@ cd ros-mcp-server
 	```
 	Or you can also launch:
 	```bash
-	launch_mcp_tunnel_.sh
+	launch_mcp_tunnel.sh
 	```
  	</details>
 

--- a/examples/7_cursor/README.md
+++ b/examples/7_cursor/README.md
@@ -10,7 +10,7 @@
 ### Prepare target robot (ROS)
 
 * Installation of Ubuntu or WSL (Windows Subsystem for Linux) on Windows.
-* Installation of ROS or ROS2. Test if ROS is installed by running Turtlesim. If you are not sure, follow, this tutorial. See [here](https://wiki.ros.org/ROS/Tutorials).
+* Installation of ROS or ROS2. Test if ROS is installed by running Turtlesim. If you are not sure, follow this tutorial. See [here](https://wiki.ros.org/ROS/Tutorials).
 
 # Tutorial
 


### PR DESCRIPTION
Closes #287

## Motivation
While running through examples 5 (Docker Turtlesim), 6 (ChatGPT), and 7 (Cursor) on macOS, I encountered several documentation typos and bugs that would cause errors or confusion for new users following the tutorials.

## Changes

### 5_docker_turtlesim/README.md
- Fix typo: `./scrips/launch.sh` -> `./scripts/launch.sh` (missing 't')
- Fix shell variable bug: `${ROS_DISTRO}$` -> `${ROS_DISTRO}` in 3 locations (trailing `$` causes shell errors when copy-pasted)

### 6_chatgpt/README.md
- Fix broken URL: `[here](chatgpt.com/download)` -> `[here](https://chatgpt.com/download)` (missing `https://` made it a relative link)
- Fix filename typo: `launch_mcp_tunnel_.sh` -> `launch_mcp_tunnel.sh` (extra underscore; the actual file is `launch/launch_mcp_tunnel.sh`)

### 7_cursor/README.md
- Fix grammar: "follow, this tutorial" -> "follow this tutorial" (extra comma)

## Backward-compatible
All changes are documentation-only, no code changes.
