### PR TITLE
refactor(services): migrate to rosapi_service()/rosapi_type(), add tool tests (step4)

### DIFF
--- a/ros_mcp/tools/services.py
+++ b/ros_mcp/tools/services.py
@@ -4,6 +4,7 @@ from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
 from ros_mcp.utils.response import _check_response, _safe_get_values
+from ros_mcp.utils.rosapi_types import rosapi_service, rosapi_type
 from ros_mcp.utils.websocket import WebSocketManager
 
 
@@ -30,8 +31,8 @@ def register_service_tools(
         """
         message = {
             "op": "call_service",
-            "service": "/rosapi/services",
-            "type": "rosapi_msgs/srv/Services",
+            "service": rosapi_service("services"),
+            "type": rosapi_type("Services"),
             "args": {},
             "id": "get_services_request_1",
         }
@@ -74,8 +75,8 @@ def register_service_tools(
 
         message = {
             "op": "call_service",
-            "service": "/rosapi/service_type",
-            "type": "rosapi_msgs/srv/ServiceType",
+            "service": rosapi_service("service_type"),
+            "type": rosapi_type("ServiceType"),
             "args": {"service": service},
             "id": f"get_service_type_request_{service.replace('/', '_')}",
         }
@@ -134,8 +135,8 @@ def register_service_tools(
             # First get the service type
             type_message = {
                 "op": "call_service",
-                "service": "/rosapi/service_type",
-                "type": "rosapi_msgs/srv/ServiceType",
+                "service": rosapi_service("service_type"),
+                "type": rosapi_type("ServiceType"),
                 "args": {"service": service},
                 "id": f"get_service_type_{service.replace('/', '_')}",
             }
@@ -157,8 +158,8 @@ def register_service_tools(
             # Get request details
             request_message = {
                 "op": "call_service",
-                "service": "/rosapi/service_request_details",
-                "type": "rosapi_msgs/srv/ServiceRequestDetails",
+                "service": rosapi_service("service_request_details"),
+                "type": rosapi_type("ServiceRequestDetails"),
                 "args": {"type": result["type"]},
                 "id": f"get_service_details_request_{result['type'].replace('/', '_')}",
             }
@@ -179,8 +180,8 @@ def register_service_tools(
             # Get response details
             response_message = {
                 "op": "call_service",
-                "service": "/rosapi/service_response_details",
-                "type": "rosapi_msgs/srv/ServiceResponseDetails",
+                "service": rosapi_service("service_response_details"),
+                "type": rosapi_type("ServiceResponseDetails"),
                 "args": {"type": result["type"]},
                 "id": f"get_service_details_response_{result['type'].replace('/', '_')}",
             }
@@ -201,8 +202,8 @@ def register_service_tools(
             # Get service providers
             provider_message = {
                 "op": "call_service",
-                "service": "/rosapi/service_node",
-                "type": "rosapi_msgs/srv/ServiceNode",
+                "service": rosapi_service("service_node"),
+                "type": rosapi_type("ServiceNode"),
                 "args": {"service": service},
                 "id": f"get_service_providers_request_{service.replace('/', '_')}",
             }

--- a/ros_mcp/tools/topics.py
+++ b/ros_mcp/tools/topics.py
@@ -11,6 +11,7 @@ from PIL import Image as PILImage
 
 from ros_mcp.tools.images import _encode_image_to_imagecontent, convert_expects_image_hint
 from ros_mcp.utils.response import _check_response, _safe_get_values
+from ros_mcp.utils.rosapi_types import rosapi_service, rosapi_type
 from ros_mcp.utils.websocket import WebSocketManager, parse_input
 
 
@@ -38,8 +39,8 @@ def register_topic_tools(
         # rosbridge service call to get topic list
         message = {
             "op": "call_service",
-            "service": "/rosapi/topics",
-            "type": "rosapi/Topics",
+            "service": rosapi_service("topics"),
+            "type": rosapi_type("Topics"),
             "args": {},
             "id": "get_topics_request_1",
         }
@@ -87,8 +88,8 @@ def register_topic_tools(
         # rosbridge service call to get topic type
         message = {
             "op": "call_service",
-            "service": "/rosapi/topic_type",
-            "type": "rosapi/TopicType",
+            "service": rosapi_service("topic_type"),
+            "type": rosapi_type("TopicType"),
             "args": {"topic": topic},
             "id": f"get_topic_type_request_{topic.replace('/', '_')}",
         }
@@ -149,8 +150,8 @@ def register_topic_tools(
             # Get topic type
             type_message = {
                 "op": "call_service",
-                "service": "/rosapi/topic_type",
-                "type": "rosapi/TopicType",
+                "service": rosapi_service("topic_type"),
+                "type": rosapi_type("TopicType"),
                 "args": {"topic": topic},
                 "id": f"get_topic_type_{topic.replace('/', '_')}",
             }
@@ -163,8 +164,8 @@ def register_topic_tools(
             # Get publishers for this topic
             publishers_message = {
                 "op": "call_service",
-                "service": "/rosapi/publishers",
-                "type": "rosapi/Publishers",
+                "service": rosapi_service("publishers"),
+                "type": rosapi_type("Publishers"),
                 "args": {"topic": topic},
                 "id": f"get_publishers_{topic.replace('/', '_')}",
             }
@@ -177,8 +178,8 @@ def register_topic_tools(
             # Get subscribers for this topic
             subscribers_message = {
                 "op": "call_service",
-                "service": "/rosapi/subscribers",
-                "type": "rosapi/Subscribers",
+                "service": rosapi_service("subscribers"),
+                "type": rosapi_type("Subscribers"),
                 "args": {"topic": topic},
                 "id": f"get_subscribers_{topic.replace('/', '_')}",
             }
@@ -226,8 +227,8 @@ def register_topic_tools(
         # rosbridge service call to get message details
         message = {
             "op": "call_service",
-            "service": "/rosapi/message_details",
-            "type": "rosapi/MessageDetails",
+            "service": rosapi_service("message_details"),
+            "type": rosapi_type("MessageDetails"),
             "args": {"type": message_type},
             "id": f"get_message_details_request_{message_type.replace('/', '_')}",
         }

--- a/tests/integration/scripts/run-connection-tests.sh
+++ b/tests/integration/scripts/run-connection-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Run connection integration tests against a specific ROS distro.
+# Usage: ./tests/integration/scripts/run-connection-tests.sh <distro>
+exec "$(dirname "$0")/run-tests.sh" "${1:?Usage: $0 <melodic|noetic|humble|jazzy>}" connection

--- a/tests/integration/scripts/run-detect-version-tests.sh
+++ b/tests/integration/scripts/run-detect-version-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Run detect_version integration tests against a specific ROS distro.
-# Usage: ./tests/integration/scripts/run-detect_version-tests.sh <distro>
+# Usage: ./tests/integration/scripts/run-detect-version-tests.sh <distro>
 exec "$(dirname "$0")/run-tests.sh" "${1:?Usage: $0 <melodic|noetic|humble|jazzy>}" detect_version

--- a/tests/integration/scripts/run-detect_version-tests.sh
+++ b/tests/integration/scripts/run-detect_version-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Run detect_version integration tests against a specific ROS distro.
+# Usage: ./tests/integration/scripts/run-detect_version-tests.sh <distro>
+exec "$(dirname "$0")/run-tests.sh" "${1:?Usage: $0 <melodic|noetic|humble|jazzy>}" detect_version

--- a/tests/integration/scripts/run-nodes-tests.sh
+++ b/tests/integration/scripts/run-nodes-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Run nodes integration tests against a specific ROS distro.
+# Usage: ./tests/integration/scripts/run-nodes-tests.sh <distro>
+exec "$(dirname "$0")/run-tests.sh" "${1:?Usage: $0 <melodic|noetic|humble|jazzy>}" nodes

--- a/tests/integration/scripts/run-services-tests.sh
+++ b/tests/integration/scripts/run-services-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Run services integration tests against a specific ROS distro.
+# Usage: ./tests/integration/scripts/run-services-tests.sh <distro>
+exec "$(dirname "$0")/run-tests.sh" "${1:?Usage: $0 <melodic|noetic|humble|jazzy>}" services

--- a/tests/integration/scripts/run-tests.sh
+++ b/tests/integration/scripts/run-tests.sh
@@ -7,7 +7,18 @@
 set -e
 cd "$(git rev-parse --show-toplevel)"
 
-DISTRO="${1:?Usage: $0 <melodic|noetic|humble|jazzy> [module]}"
+if [ -z "${1:-}" ]; then
+    MODULES=$(ls tests/integration/test_*.py 2>/dev/null \
+        | sed 's|tests/integration/test_||;s|\.py||' \
+        | grep -v quick_detect \
+        | tr '\n' ', ' | sed 's/,$//')
+    echo "Usage: $0 <distro> [module]"
+    echo "Distros: melodic, noetic, humble, jazzy"
+    echo "Modules: $MODULES"
+    exit 1
+fi
+
+DISTRO="$1"
 MODULE="${2:-}"
 COMPOSE="tests/integration/docker-compose.yml"
 

--- a/tests/integration/scripts/run-tests.sh
+++ b/tests/integration/scripts/run-tests.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 # Run integration tests against a specific ROS distro.
-# Usage: ./tests/integration/scripts/run-tests.sh <distro>
+# Usage: ./tests/integration/scripts/run-tests.sh <distro> [module]
 # Example: ./tests/integration/scripts/run-tests.sh noetic
+# Example: ./tests/integration/scripts/run-tests.sh humble topics
 
 set -e
 cd "$(git rev-parse --show-toplevel)"
 
-DISTRO="${1:?Usage: $0 <melodic|noetic|humble|jazzy>}"
+DISTRO="${1:?Usage: $0 <melodic|noetic|humble|jazzy> [module]}"
+MODULE="${2:-}"
 COMPOSE="tests/integration/docker-compose.yml"
 
 declare -A DOCKERFILES=(
@@ -54,7 +56,17 @@ uv run python tests/integration/test_quick_detect.py
 # Run pytest
 echo ""
 echo "--- Pytest ---"
-uv run pytest tests/integration/ -v --ros-distro "$DISTRO" --skip-compose
+if [ -n "$MODULE" ]; then
+    TEST_PATH="tests/integration/test_${MODULE}.py"
+    if [ ! -f "$TEST_PATH" ]; then
+        echo "Unknown module: $MODULE"
+        echo "Available: $(ls tests/integration/test_*.py | sed 's|tests/integration/test_||;s|\.py||' | tr '\n' ' ')"
+        exit 1
+    fi
+    uv run pytest "$TEST_PATH" -v --ros-distro "$DISTRO" --skip-compose
+else
+    uv run pytest tests/integration/ -v --ros-distro "$DISTRO" --skip-compose
+fi
 
 # Tear down
 echo ""

--- a/tests/integration/scripts/run-topics-tests.sh
+++ b/tests/integration/scripts/run-topics-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Run topics integration tests against a specific ROS distro.
+# Usage: ./tests/integration/scripts/run-topics-tests.sh <distro>
+exec "$(dirname "$0")/run-tests.sh" "${1:?Usage: $0 <melodic|noetic|humble|jazzy>}" topics

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -80,9 +80,18 @@ class TestGetServiceDetails:
 class TestCallService:
     """Verify call_service MCP tool can call a live service."""
 
+    def test_call_clear(self, tools):
+        """call_service for /clear should succeed (clears drawing traces)."""
+        type_result = tools["get_service_type"](service="/clear")
+        result = tools["call_service"](
+            service_name="/clear",
+            service_type=type_result["type"],
+            request={},
+        )
+        assert result["success"] is True
+
     def test_call_spawn_turtle(self, tools):
         """call_service for /spawn should create a new turtle."""
-        # Use a unique name to avoid conflicts across test runs
         turtle_name = f"test_turtle_{int(time.time_ns())}"
         type_result = tools["get_service_type"](service="/spawn")
         spawn_type = type_result["type"]
@@ -92,3 +101,12 @@ class TestCallService:
             request={"x": 3.0, "y": 3.0, "theta": 0.0, "name": turtle_name},
         )
         assert result["success"] is True
+
+    def test_call_nonexistent_service(self, tools):
+        """call_service for a nonexistent service should return an error."""
+        result = tools["call_service"](
+            service_name="/this_service_does_not_exist",
+            service_type="std_srvs/srv/Empty",
+            request={},
+        )
+        assert result["success"] is False

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -1,0 +1,94 @@
+"""Integration tests for service tools.
+
+These tests call the actual MCP tool functions (get_services, get_service_type,
+get_service_details, call_service) against a live rosbridge container.
+"""
+
+import time
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+
+class TestGetServices:
+    """Verify get_services MCP tool returns the service list."""
+
+    def test_returns_services(self, tools):
+        """get_services should return services and service_count."""
+        result = tools["get_services"]()
+        assert "services" in result
+        assert "service_count" in result
+        assert result["service_count"] > 0
+        assert result["service_count"] == len(result["services"])
+
+    def test_includes_rosapi_services(self, tools):
+        """rosapi services should be present (rosapi node is running)."""
+        result = tools["get_services"]()
+        services = result["services"]
+        assert any("nodes" in s for s in services), f"nodes service not in {services}"
+
+    def test_includes_turtlesim_services(self, tools):
+        """turtlesim services like /clear or /spawn should be present."""
+        result = tools["get_services"]()
+        services = result["services"]
+        assert any("spawn" in s for s in services), f"spawn not in {services}"
+
+
+class TestGetServiceType:
+    """Verify get_service_type MCP tool returns the service type."""
+
+    def test_known_service_type(self, tools):
+        """get_service_type for a turtlesim service should return a type string."""
+        result = tools["get_service_type"](service="/kill")
+        assert "type" in result
+        assert len(result["type"]) > 0
+
+    def test_empty_service_returns_error(self, tools):
+        """get_service_type with empty string should return error."""
+        result = tools["get_service_type"](service="")
+        assert "error" in result
+
+    def test_whitespace_service_returns_error(self, tools):
+        """get_service_type with whitespace should return error."""
+        result = tools["get_service_type"](service="   ")
+        assert "error" in result
+
+
+class TestGetServiceDetails:
+    """Verify get_service_details MCP tool returns full service definition."""
+
+    def test_spawn_details(self, tools):
+        """get_service_details for /spawn should return request/response fields."""
+        result = tools["get_service_details"](service="/spawn")
+        assert result["service"] == "/spawn"
+        assert len(result["type"]) > 0
+        assert "request" in result
+        assert "response" in result
+
+    def test_empty_service_returns_error(self, tools):
+        """get_service_details with empty string should return error."""
+        result = tools["get_service_details"](service="")
+        assert "error" in result
+
+    def test_whitespace_service_returns_error(self, tools):
+        """get_service_details with whitespace should return error."""
+        result = tools["get_service_details"](service="   ")
+        assert "error" in result
+
+
+class TestCallService:
+    """Verify call_service MCP tool can call a live service."""
+
+    def test_call_spawn_turtle(self, tools):
+        """call_service for /spawn should create a new turtle."""
+        # Use a unique name to avoid conflicts across test runs
+        turtle_name = f"test_turtle_{int(time.time_ns())}"
+        type_result = tools["get_service_type"](service="/spawn")
+        spawn_type = type_result["type"]
+        result = tools["call_service"](
+            service_name="/spawn",
+            service_type=spawn_type,
+            request={"x": 3.0, "y": 3.0, "theta": 0.0, "name": turtle_name},
+        )
+        assert result["success"] is True

--- a/tests/integration/test_topics.py
+++ b/tests/integration/test_topics.py
@@ -5,6 +5,7 @@ get_topic_details, get_message_details, subscribe_once, subscribe_for_duration,
 publish_once, publish_for_durations) against a live rosbridge container.
 """
 
+import json
 import time
 
 import pytest
@@ -125,9 +126,11 @@ class TestSubscribeForDuration:
             duration=2.0,
             max_messages=5,
         )
-        assert "messages" in result, f"subscribe_for_duration failed: {result}"
-        assert result["collected_count"] > 0
-        assert result["topic"] == "/turtle1/pose"
+        # subscribe_for_duration returns a ToolResult; summary is in content[0].text
+        assert hasattr(result, "content"), f"subscribe_for_duration failed: {result}"
+        summary = json.loads(result.content[0].text)
+        assert summary["collected_count"] > 0
+        assert summary["topic"] == "/turtle1/pose"
 
     def test_missing_args_returns_error(self, tools):
         """subscribe_for_duration without topic/msg_type should return error."""

--- a/tests/integration/test_topics.py
+++ b/tests/integration/test_topics.py
@@ -1,0 +1,108 @@
+"""Integration tests for topic tools (step 3).
+
+These tests call the actual MCP tool functions (get_topics, get_topic_type,
+get_topic_details, get_message_details, subscribe_once) against a live
+rosbridge container.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+
+class TestGetTopics:
+    """Verify get_topics MCP tool returns the topic list."""
+
+    def test_returns_topics(self, tools):
+        """get_topics should return topics, types, and topic_count."""
+        result = tools["get_topics"]()
+        assert "topics" in result
+        assert "types" in result
+        assert "topic_count" in result
+        assert result["topic_count"] > 0
+        assert result["topic_count"] == len(result["topics"])
+        assert len(result["types"]) == len(result["topics"])
+
+    def test_includes_turtle_pose(self, tools):
+        """turtlesim publishes /turtle1/pose — it should appear in topics."""
+        result = tools["get_topics"]()
+        assert any("/turtle1/pose" in t for t in result["topics"]), (
+            f"/turtle1/pose not in {result['topics']}"
+        )
+
+    def test_includes_cmd_vel(self, tools):
+        """turtlesim subscribes to /turtle1/cmd_vel — it should appear in topics."""
+        result = tools["get_topics"]()
+        assert any("cmd_vel" in t for t in result["topics"]), (
+            f"cmd_vel not in {result['topics']}"
+        )
+
+
+class TestGetTopicType:
+    """Verify get_topic_type MCP tool returns the message type."""
+
+    def test_turtle_pose_type(self, tools):
+        """get_topic_type for /turtle1/pose should return turtlesim/Pose."""
+        result = tools["get_topic_type"](topic="/turtle1/pose")
+        assert "type" in result
+        assert "Pose" in result["type"]
+
+    def test_empty_topic_returns_error(self, tools):
+        """get_topic_type with empty string should return error."""
+        result = tools["get_topic_type"](topic="")
+        assert "error" in result
+
+
+class TestGetTopicDetails:
+    """Verify get_topic_details MCP tool returns type + publishers + subscribers."""
+
+    def test_pose_details(self, tools):
+        """get_topic_details for /turtle1/pose should have a publisher (turtlesim)."""
+        result = tools["get_topic_details"](topic="/turtle1/pose")
+        assert result["topic"] == "/turtle1/pose"
+        assert "Pose" in result["type"]
+        assert result["publisher_count"] > 0
+
+    def test_empty_topic_returns_error(self, tools):
+        """get_topic_details with empty string should return error."""
+        result = tools["get_topic_details"](topic="")
+        assert "error" in result
+
+
+class TestGetMessageDetails:
+    """Verify get_message_details MCP tool returns message structure."""
+
+    def test_twist_structure(self, tools):
+        """get_message_details for geometry_msgs/Twist should return fields."""
+        result = tools["get_message_details"](message_type="geometry_msgs/Twist")
+        assert "structure" in result, f"Unexpected result: {result}"
+        assert len(result["structure"]) > 0
+
+    def test_empty_type_returns_error(self, tools):
+        """get_message_details with empty string should return error."""
+        result = tools["get_message_details"](message_type="")
+        assert "error" in result
+
+
+class TestSubscribeOnce:
+    """Verify subscribe_once MCP tool receives a message from a live topic."""
+
+    def test_subscribe_to_pose(self, tools):
+        """subscribe_once on /turtle1/pose should receive a Pose message."""
+        # Get the actual type from get_topic_type (differs between ROS 1 and 2)
+        type_result = tools["get_topic_type"](topic="/turtle1/pose")
+        pose_type = type_result["type"]
+        result = tools["subscribe_once"](
+            topic="/turtle1/pose",
+            msg_type=pose_type,
+            timeout=5.0,
+        )
+        assert "msg" in result, f"subscribe_once failed: {result}"
+        msg = result["msg"]
+        assert "x" in msg
+        assert "y" in msg
+
+    def test_missing_args_returns_error(self, tools):
+        """subscribe_once without topic/msg_type should return error."""
+        result = tools["subscribe_once"]()
+        assert "error" in result

--- a/tests/integration/test_topics.py
+++ b/tests/integration/test_topics.py
@@ -1,13 +1,22 @@
-"""Integration tests for topic tools (step 3).
+"""Integration tests for topic tools.
 
 These tests call the actual MCP tool functions (get_topics, get_topic_type,
-get_topic_details, get_message_details, subscribe_once) against a live
-rosbridge container.
+get_topic_details, get_message_details, subscribe_once, subscribe_for_duration,
+publish_once, publish_for_durations) against a live rosbridge container.
 """
+
+import time
 
 import pytest
 
 pytestmark = [pytest.mark.integration]
+
+
+def _get_type(tools, topic):
+    """Get the msg type for a topic, failing the test with a clear message if not found."""
+    result = tools["get_topic_type"](topic=topic)
+    assert "type" in result, f"get_topic_type failed for {topic}: {result}"
+    return result["type"]
 
 
 class TestGetTopics:
@@ -33,9 +42,7 @@ class TestGetTopics:
     def test_includes_cmd_vel(self, tools):
         """turtlesim subscribes to /turtle1/cmd_vel — it should appear in topics."""
         result = tools["get_topics"]()
-        assert any("cmd_vel" in t for t in result["topics"]), (
-            f"cmd_vel not in {result['topics']}"
-        )
+        assert any("cmd_vel" in t for t in result["topics"]), f"cmd_vel not in {result['topics']}"
 
 
 class TestGetTopicType:
@@ -89,9 +96,7 @@ class TestSubscribeOnce:
 
     def test_subscribe_to_pose(self, tools):
         """subscribe_once on /turtle1/pose should receive a Pose message."""
-        # Get the actual type from get_topic_type (differs between ROS 1 and 2)
-        type_result = tools["get_topic_type"](topic="/turtle1/pose")
-        pose_type = type_result["type"]
+        pose_type = _get_type(tools, "/turtle1/pose")
         result = tools["subscribe_once"](
             topic="/turtle1/pose",
             msg_type=pose_type,
@@ -106,3 +111,122 @@ class TestSubscribeOnce:
         """subscribe_once without topic/msg_type should return error."""
         result = tools["subscribe_once"]()
         assert "error" in result
+
+
+class TestSubscribeForDuration:
+    """Verify subscribe_for_duration MCP tool collects messages over time."""
+
+    def test_collect_pose_messages(self, tools):
+        """subscribe_for_duration on /turtle1/pose should collect multiple messages."""
+        pose_type = _get_type(tools, "/turtle1/pose")
+        result = tools["subscribe_for_duration"](
+            topic="/turtle1/pose",
+            msg_type=pose_type,
+            duration=2.0,
+            max_messages=5,
+        )
+        assert "messages" in result, f"subscribe_for_duration failed: {result}"
+        assert result["collected_count"] > 0
+        assert result["topic"] == "/turtle1/pose"
+
+    def test_missing_args_returns_error(self, tools):
+        """subscribe_for_duration without topic/msg_type should return error."""
+        result = tools["subscribe_for_duration"]()
+        assert "error" in result
+
+
+class TestPublishOnce:
+    """Verify publish_once MCP tool sends a message."""
+
+    def test_publish_cmd_vel(self, tools):
+        """publish_once should successfully publish a Twist to /turtle1/cmd_vel."""
+        cmd_vel_type = _get_type(tools, "/turtle1/cmd_vel")
+        result = tools["publish_once"](
+            topic="/turtle1/cmd_vel",
+            msg_type=cmd_vel_type,
+            msg={"linear": {"x": 0.1, "y": 0.0, "z": 0.0}},
+        )
+        assert result.get("success") is True, f"publish_once failed: {result}"
+
+    def test_empty_msg_returns_error(self, tools):
+        """publish_once with empty msg should return error."""
+        result = tools["publish_once"](
+            topic="/turtle1/cmd_vel",
+            msg_type="geometry_msgs/Twist",
+            msg={},
+        )
+        assert "error" in result
+
+    def test_missing_topic_returns_error(self, tools):
+        """publish_once without topic should return error."""
+        result = tools["publish_once"]()
+        assert "error" in result
+
+
+class TestPublishForDurations:
+    """Verify publish_for_durations MCP tool sends a sequence of messages."""
+
+    def test_publish_sequence(self, tools):
+        """publish_for_durations should publish a message sequence."""
+        cmd_vel_type = _get_type(tools, "/turtle1/cmd_vel")
+        result = tools["publish_for_durations"](
+            topic="/turtle1/cmd_vel",
+            msg_type=cmd_vel_type,
+            messages=[{"linear": {"x": 0.1}}, {"linear": {"x": 0.0}}],
+            durations=[0.5, 0.1],
+        )
+        assert result.get("success") is True, f"publish_for_durations failed: {result}"
+        # published_count may be < total on some distros due to rosbridge
+        # response timing in non-streaming mode (rate_hz=0)
+        assert result["published_count"] >= 1
+
+    def test_empty_sequence(self, tools):
+        """publish_for_durations with empty lists should succeed with 0 published."""
+        cmd_vel_type = _get_type(tools, "/turtle1/cmd_vel")
+        result = tools["publish_for_durations"](
+            topic="/turtle1/cmd_vel",
+            msg_type=cmd_vel_type,
+            messages=[],
+            durations=[],
+        )
+        assert result.get("success") is True
+        assert result["published_count"] == 0
+
+    def test_missing_args_returns_error(self, tools):
+        """publish_for_durations without topic/msg_type should return error."""
+        result = tools["publish_for_durations"]()
+        assert "error" in result
+
+
+class TestPublishAndSubscribe:
+    """End-to-end: publish cmd_vel and verify turtle moves via pose subscription."""
+
+    def test_turtle_moves_after_publish(self, tools):
+        """Publish a velocity, then check that the turtle's position changed."""
+        pose_type = _get_type(tools, "/turtle1/pose")
+
+        # Get initial pose
+        before = tools["subscribe_once"](topic="/turtle1/pose", msg_type=pose_type, timeout=5.0)
+        assert "msg" in before, f"Failed to get initial pose: {before}"
+        x_before = before["msg"]["x"]
+
+        # Publish forward velocity
+        cmd_vel_type = _get_type(tools, "/turtle1/cmd_vel")
+        pub_result = tools["publish_for_durations"](
+            topic="/turtle1/cmd_vel",
+            msg_type=cmd_vel_type,
+            messages=[{"linear": {"x": 1.0, "y": 0.0, "z": 0.0}}],
+            durations=[1.0],
+            rate_hz=10,
+        )
+        assert pub_result.get("success") is True
+
+        # Wait briefly for physics to update
+        time.sleep(0.5)
+
+        # Get new pose
+        after = tools["subscribe_once"](topic="/turtle1/pose", msg_type=pose_type, timeout=5.0)
+        assert "msg" in after, f"Failed to get new pose: {after}"
+        x_after = after["msg"]["x"]
+
+        assert x_after != x_before, f"Turtle did not move: x_before={x_before}, x_after={x_after}"


### PR DESCRIPTION
## Summary

Step 4 of 6 — targets `feature/step3` (#281)

- Replace 12 hardcoded `/rosapi/` strings in `services.py` (6 service paths + 6 type strings) with `rosapi_service()`/`rosapi_type()`
- Integration tests call actual MCP tools (`get_services`, `get_service_type`, `get_service_details`, `call_service`) directly
- Tests cover happy paths and negative paths (empty/whitespace input, nonexistent service)

## Changes

- **`ros_mcp/tools/services.py`** — import helpers, replace 12 hardcoded strings (+13 -12)
- **`tests/integration/test_services.py`** — 12 tests:
  - `get_services`: returns services, includes rosapi services, includes turtlesim services
  - `get_service_type`: known service type, empty error, whitespace error
  - `get_service_details`: spawn details, empty error, whitespace error
  - `call_service`: clear (no args), spawn turtle (with args), nonexistent service (error)
- **`tests/integration/scripts/run-services-tests.sh`** — per-module test runner

## Testing

12 tests pass on Jazzy (native), verified one-by-one against live rosbridge + turtlesim.

## PR stack

| Step | PR | Status |
|------|----|--------|
| Step 0: detection + Docker infra | #276 | merged |
| Step 1: connection + robot config | #278 | merged |
| Step 2: nodes | #280 | open |
| Step 3: topics | #281 | open |
| **Step 4: services** | **this PR** | **open** |
| Step 5: actions + parameters | (not created) | — |
| Step 6: resources | (not created) | — |
